### PR TITLE
Use NullHandler when no logfile is specified

### DIFF
--- a/pycsw/log.py
+++ b/pycsw/log.py
@@ -94,6 +94,10 @@ class Log(logging.Logger):
                 raise RuntimeError, \
                 ('Invalid server configuration: server.logfile access denied.\
                 Make sure filepath exists and is writable. %s', str(err))
+        else:
+            nullhandler = logging.NullHandler()
+            self.addHandler(nullhandler)
+ 
         self.info('Logging initialized (level: %s).' % loglevel)
 
         if loglevel == 'DEBUG':  #turn on CGI debugging


### PR DESCRIPTION
When no logfile is specified, the a warning "No handlers could be found for logger pycsw could be found" pops up in tests. This adds a handler that does nothing and fixes the warning message.
