### PR TITLE
Fix #254: Empty queriable columns while harvesting ISO metadata.

### DIFF
--- a/pycsw/metadata.py
+++ b/pycsw/metadata.py
@@ -876,9 +876,9 @@ def _parse_iso(context, repos, exml):
             _set(context, recobj, 'pycsw:Contributor', md.identification.contributor)
 
         if (hasattr(md.identification, 'contact') and 
-        hasattr(md.identification.contact, 'organization') and
-        len(md.identification.contact) > 0):
-            _set(context, recobj, 'pycsw:OrganizationName', md.identification.contact[0].organization)
+            len(md.identification.contact) > 0):
+            all_orgs = set([item.organization for item in md.identification.contact if hasattr(item, 'organization') and item.organization is not None])
+            _set(context, recobj, 'pycsw:OrganizationName', ';'.join(all_orgs))
 
         if len(md.identification.securityconstraints) > 0:
             _set(context, recobj, 'pycsw:SecurityConstraints', 


### PR DESCRIPTION
Fix #254: Add all organizations to apiso:OrganizationName
