### PR TITLE
Fix exception in logger when response contains unicode.

### DIFF
--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -2381,10 +2381,9 @@ class Csw(object):
             % self.encoding
             appinfo = '<!-- pycsw %s -->\n' % self.context.version
 
-        LOGGER.debug('Response:\n%s' % response)
-
-        s = '%s%s%s' % (xmldecl, appinfo, response)
-        return s.encode(self.encoding)
+        s = (u'%s%s%s' % (xmldecl, appinfo, response)).encode(self.encoding)
+        LOGGER.debug('Response:\n%s', s)
+        return s
 
 
     def _gen_soap_wrapper(self):


### PR DESCRIPTION
Running some internal unit tests to check unicode handling, I ran into an exception which was caught internally in logging and dumped to stderr - the actual execution wasn't affected:

```
Traceback (most recent call last):
  File "/usr/lib64/python2.6/logging/handlers.py", line 783, in emit
    self.socket.send(msg)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2603' in position 1893: ordinal not in range(128)
```

The test scenario was a bit convoluted: running nose which captures all logging, `contact_name = 'Captain ☃ for you!'`, encoding=utf8, and a GetCapabilities request.

Eventually I tracked it down to the attached - if the system logger can't deal with the characters then you get that error - encoding as a string seems to fix it and there's no exception logged to stderr.

> I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
