### PR TITLE
CSW harvesting: skip bad metadata

### DIFF
--- a/pycsw/metadata.py
+++ b/pycsw/metadata.py
@@ -220,10 +220,17 @@ def _parse_csw(context, repos, record, identifier, pagesize=10):
         except Exception as err:  # this is a CSW, but server rejects query
             raise RuntimeError(md.response)
         for k, v in md.records.iteritems():
-            if csw_typenames == 'gmd:MD_Metadata':
-                recobjs.append(_parse_iso(context, repos, etree.fromstring(v.xml)))
-            else:
-                recobjs.append(_parse_dc(context, repos, etree.fromstring(v.xml)))
+            # try to parse metadata
+            try:
+                LOGGER.debug('Parsing metadata record: %s', v.xml)
+                if csw_typenames == 'gmd:MD_Metadata':
+                    recobjs.append(_parse_iso(context, repos,
+                                              etree.fromstring(v.xml)))
+                else:
+                    recobjs.append(_parse_dc(context, repos,
+                                             etree.fromstring(v.xml)))
+            except Exception as err:  # parsing failed for some reason
+                LOGGER.warning('Metadata parsing failed %s', err)
 
     return recobjs
 

--- a/tests/expected/suites_harvesting_post_Harvest-csw-iso.xml
+++ b/tests/expected/suites_harvesting_post_Harvest-csw-iso.xml
@@ -3,7 +3,7 @@
 <csw:HarvestResponse xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:apiso="http://www.opengis.net/cat/csw/apiso/1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:dif="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:ogc="http://www.opengis.net/ogc" xmlns:fgdc="http://www.opengis.net/cat/csw/csdgm" xmlns:inspire_ds="http://inspire.ec.europa.eu/schemas/inspire_ds/1.0" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-publication.xsd">
   <csw:TransactionResponse version="2.0.2">
     <csw:TransactionSummary>
-      <csw:totalInserted>41</csw:totalInserted>
+      <csw:totalInserted>50</csw:totalInserted>
       <csw:totalUpdated>0</csw:totalUpdated>
       <csw:totalDeleted>0</csw:totalDeleted>
     </csw:TransactionSummary>
@@ -109,10 +109,6 @@
         <dc:title/>
       </csw:BriefRecord>
       <csw:BriefRecord>
-        <dc:identifier>PYCSW_IDENTIFIER</dc:identifier>
-        <dc:title/>
-      </csw:BriefRecord>
-      <csw:BriefRecord>
         <dc:identifier>PYCSW_IDENTIFIER_gen0</dc:identifier>
         <dc:title/>
       </csw:BriefRecord>
@@ -146,6 +142,46 @@
       </csw:BriefRecord>
       <csw:BriefRecord>
         <dc:identifier>PYCSW_IDENTIFIER_gen1</dc:identifier>
+        <dc:title/>
+      </csw:BriefRecord>
+      <csw:BriefRecord>
+        <dc:identifier>PYCSW_IDENTIFIER</dc:identifier>
+        <dc:title/>
+      </csw:BriefRecord>
+      <csw:BriefRecord>
+        <dc:identifier>PYCSW_IDENTIFIER</dc:identifier>
+        <dc:title/>
+      </csw:BriefRecord>
+      <csw:BriefRecord>
+        <dc:identifier>PYCSW_IDENTIFIER</dc:identifier>
+        <dc:title/>
+      </csw:BriefRecord>
+      <csw:BriefRecord>
+        <dc:identifier>PYCSW_IDENTIFIER</dc:identifier>
+        <dc:title/>
+      </csw:BriefRecord>
+      <csw:BriefRecord>
+        <dc:identifier>PYCSW_IDENTIFIER</dc:identifier>
+        <dc:title/>
+      </csw:BriefRecord>
+      <csw:BriefRecord>
+        <dc:identifier>PYCSW_IDENTIFIER</dc:identifier>
+        <dc:title/>
+      </csw:BriefRecord>
+      <csw:BriefRecord>
+        <dc:identifier>PYCSW_IDENTIFIER</dc:identifier>
+        <dc:title/>
+      </csw:BriefRecord>
+      <csw:BriefRecord>
+        <dc:identifier>PYCSW_IDENTIFIER</dc:identifier>
+        <dc:title/>
+      </csw:BriefRecord>
+      <csw:BriefRecord>
+        <dc:identifier>PYCSW_IDENTIFIER</dc:identifier>
+        <dc:title/>
+      </csw:BriefRecord>
+      <csw:BriefRecord>
+        <dc:identifier>PYCSW_IDENTIFIER</dc:identifier>
         <dc:title/>
       </csw:BriefRecord>
       <csw:BriefRecord>

--- a/tests/expected/suites_harvesting_post_Harvest-zzz-post-GetRecords-filter-wfs-iso.xml
+++ b/tests/expected/suites_harvesting_post_Harvest-zzz-post-GetRecords-filter-wfs-iso.xml
@@ -126,16 +126,16 @@
               <gmd:geographicElement>
                 <gmd:EX_GeographicBoundingBox>
                   <gmd:westBoundLongitude>
-                    <gco:Decimal>-189.85</gco:Decimal>
+                    <gco:Decimal>-214.96</gco:Decimal>
                   </gmd:westBoundLongitude>
                   <gmd:eastBoundLongitude>
-                    <gco:Decimal>190.98</gco:Decimal>
+                    <gco:Decimal>214.94</gco:Decimal>
                   </gmd:eastBoundLongitude>
                   <gmd:southBoundLatitude>
-                    <gco:Decimal>-176.73</gco:Decimal>
+                    <gco:Decimal>-185.44</gco:Decimal>
                   </gmd:southBoundLatitude>
                   <gmd:northBoundLatitude>
-                    <gco:Decimal>212.97</gco:Decimal>
+                    <gco:Decimal>244.46</gco:Decimal>
                   </gmd:northBoundLatitude>
                 </gmd:EX_GeographicBoundingBox>
               </gmd:geographicElement>

--- a/tests/expected/suites_harvesting_post_Transaction-000-delete-all.xml
+++ b/tests/expected/suites_harvesting_post_Transaction-000-delete-all.xml
@@ -4,6 +4,6 @@
   <csw:TransactionSummary>
     <csw:totalInserted>0</csw:totalInserted>
     <csw:totalUpdated>0</csw:totalUpdated>
-    <csw:totalDeleted>108</csw:totalDeleted>
+    <csw:totalDeleted>117</csw:totalDeleted>
   </csw:TransactionSummary>
 </csw:TransactionResponse>


### PR DESCRIPTION
cc @davicustodio

As per http://osgeo-org.1560.x6.nabble.com/Making-Harvesting-in-a-dedicated-server-PyCSW-from-catalogs-CSW-in-GeoNode-servers-td5212012.html, when harvesting CSW metadata records, if the record is malformed, throw a logging warning and skip.