### PR TITLE
refactored the cgi wrapper to use code from wsgi

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -45,7 +45,7 @@ The 4 minute install:
   # - server.home
   # - repository.database
   # set server.url to http://localhost:8000/
-  $ python csw.wsgi
+  $ python pycsw/wsgi.py
   $ curl http://localhost:8000/?service=CSW&version=2.0.2&request=GetCapabilities
 
 
@@ -80,7 +80,9 @@ The Clean and Proper Way
   $ python setup.py build
   $ python setup.py install
 
-At this point, pycsw is installed as a library and requires a CGI ``csw.py`` or WSGI ``csw.wsgi`` script to be served into your web server environment (see below for WSGI configuration/deployment).
+At this point, pycsw is installed as a library and requires a CGI ``csw.py``
+or WSGI ``pycsw/wsgi.py`` script to be served into your web server environment
+(see below for WSGI configuration/deployment).
 
 .. _pypi:
 
@@ -165,7 +167,8 @@ By default, ``default.cfg`` is at the root of the pycsw install.  If pycsw is se
 Running on WSGI
 ---------------
 
-pycsw supports the `Web Server Gateway Interface`_ (WSGI).  To run pycsw in WSGI mode, use ``csw.wsgi`` in your WSGI server environment.
+pycsw supports the `Web Server Gateway Interface`_ (WSGI).  To run pycsw in
+WSGI mode, use ``pycsw/wsgi.py`` in your WSGI server environment.
 
 .. note::
 
@@ -179,7 +182,7 @@ Below is an example of configuring with Apache:
 
   WSGIDaemonProcess host1 home=/var/www/pycsw processes=2
   WSGIProcessGroup host1
-  WSGIScriptAlias /pycsw-wsgi /var/www/pycsw/csw.wsgi
+  WSGIScriptAlias /pycsw-wsgi /var/www/pycsw/wsgi.py
   <Directory /var/www/pycsw>
     Order deny,allow
     Allow from all
@@ -190,7 +193,7 @@ or use the `WSGI reference implementation`_:
 
 .. code-block:: bash
 
-  $ python ./csw.wsgi
+  $ python ./pycsw/wsgi.py
   Serving on port 8000...
 
 which will publish pycsw to ``http://localhost:8000/``

--- a/etc/dist/opensuse/python-pycsw.spec
+++ b/etc/dist/opensuse/python-pycsw.spec
@@ -89,7 +89,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/apache2/conf.d
 #mv data %{buildroot}/srv/www/htdocs/pycsw/
 mv tests %{buildroot}/srv/www/htdocs/pycsw/
 mv csw.py %{buildroot}/srv/www/htdocs/pycsw/
-mv csw.wsgi %{buildroot}/srv/www/htdocs/pycsw/
+mv pycsw/wsgi.py %{buildroot}/srv/www/htdocs/pycsw/
 mv COMMITTERS.txt %{buildroot}/srv/www/htdocs/pycsw/
 mv default-sample.cfg %{buildroot}/srv/www/htdocs/pycsw/
 mv HISTORY.txt %{buildroot}/srv/www/htdocs/pycsw/

--- a/pavement.py
+++ b/pavement.py
@@ -283,7 +283,7 @@ def test(options):
 @task
 def start(options):
     """Start local WSGI server instance"""
-    sh('python csw.wsgi 8000 &')
+    sh('python pycsw/wsgi.py 8000 &')
     time.sleep(10)
 
 
@@ -291,7 +291,7 @@ def start(options):
 def stop():
     """Stop local WSGI server instance"""
 
-    kill_process('python', 'csw.wsgi')
+    kill_process('python', 'pycsw/wsgi.py')
 
 
 @task

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -205,31 +205,6 @@ class Csw(object):
         else:
             return path
 
-    def dispatch_cgi(self):
-        ''' CGI handler '''
-
-        if hasattr(self,'response'):
-            return self._write_response()
-
-        LOGGER.debug('CGI mode detected')
-
-        cgifs = cgi.FieldStorage(keep_blank_values=1)
-
-        if cgifs.file:  # it's a POST request
-            self.request = cgifs.file.read()
-            self.requesttype = 'POST'
-            LOGGER.debug('Request type: POST.  Request:\n%s\n', self.request)
-
-        else:  # it's a GET request
-            self.requesttype = 'GET'
-            self.request = 'http://%s%s' % \
-            (self.environ['HTTP_HOST'], self.environ['REQUEST_URI'])
-            LOGGER.debug('Request type: GET.  Request:\n%s\n', self.request)
-            for key in cgifs.keys():
-                self.kvp[key] = cgifs[key].value
-
-        return self.dispatch()
-
     def dispatch_wsgi(self):
         ''' WSGI handler '''
 

--- a/pycsw/wsgi.py
+++ b/pycsw/wsgi.py
@@ -36,7 +36,7 @@
 # WSGIDaemonProcess host1 home=/var/www/pycsw processes=2
 # WSGIProcessGroup host1
 #
-# WSGIScriptAlias /pycsw-wsgi /var/www/pycsw/csw.wsgi
+# WSGIScriptAlias /pycsw-wsgi /var/www/pycsw/wsgi.py
 #
 # <Directory /var/www/pycsw>
 #  Order deny,allow
@@ -45,7 +45,7 @@
 #
 # or invoke this script from the command line:
 #
-# $ python ./csw.wsgi
+# $ python ./pycsw/wsgi.py
 #
 # which will publish pycsw to:
 #
@@ -55,11 +55,12 @@
 from StringIO import StringIO
 import os
 import sys
-
-app_path = os.path.dirname(__file__)
-sys.path.append(app_path)
+import urlparse
 
 from pycsw import server
+
+
+PYCSW_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 def application(env, start_response):
@@ -72,15 +73,15 @@ def application(env, start_response):
     if env['QUERY_STRING'].lower().find('config') != -1:
         for kvp in env['QUERY_STRING'].split('&'):
             if kvp.lower().find('config') != -1:
-                config = kvp.split('=')[1]
+                config = urlparse.unquote(kvp.split('=')[1])
 
     if not os.path.isabs(config):
-        config = os.path.join(app_path, config)
+        config = os.path.join(PYCSW_ROOT, config)
 
     if 'HTTP_HOST' in env and ':' in env['HTTP_HOST']:
         env['HTTP_HOST'] = env['HTTP_HOST'].split(':')[0]
 
-    env['local.app_root'] = app_path
+    env['local.app_root'] = PYCSW_ROOT
 
     csw = server.Csw(config, env)
 


### PR DESCRIPTION
This pull request refactors the `csw.py` cgi wrapper in order to reuse the code from the WSGI wrapper.

Since pycsw already has a WSGI wrapper that makes use of python's `wsgiref` library and since wsgiref includes a handler for CGI, it is possible to reuse the same wrapper code to handle both WSGI and CGI. This makes it possible to be a bit DRYer ;)

Changed stuff:

* Removed most code from the CGI wrapper script. yay!

* Removed the `pycsw.server.dispatch_cgi` method. We do not need it now that CGI is being handled by WSGI

* The `csw.wsgi` module had to be moved inside the `pycsw` package in order to make it be importable in a robust way (we do not need to mess with sys.path if pycsw is already installed and this module is a part of it)

* While moving `csw.wsgi` I've also renamed it to `wsgi.py` in order to make it a bit more standard

* Updated the installation docs

* Updated the opensuse build recipe, but I must admit that I'm not sure of the changes, since this is not something I had done before

* Updated the `pavement.py` file in order to update the new path of the wsgi wrapper