### PR TITLE
declare common XML parser (#380)

### DIFF
--- a/pycsw/core/admin.py
+++ b/pycsw/core/admin.py
@@ -330,7 +330,7 @@ def load_records(context, database, table, xml_dirpath, recursive=False, force_u
         LOGGER.info('Processing file %s (%d of %d)', recfile, counter, total)
         # read document
         try:
-            exml = etree.parse(recfile)
+            exml = etree.parse(recfile, context.parser)
         except Exception as err:
             LOGGER.warn('XML document is not well-formed: %s', str(err))
             continue

--- a/pycsw/core/config.py
+++ b/pycsw/core/config.py
@@ -29,6 +29,7 @@
 # =================================================================
 
 import logging
+from pycsw.core.etree import etree
 from pycsw import __version__
 
 LOGGER = logging.getLogger(__name__)
@@ -43,6 +44,8 @@ class StaticContext(object):
         self.version = __version__
 
         self.ogc_schemas_base = 'http://schemas.opengis.net'
+
+        self.parser = etree.XMLParser(resolve_entities=False)
 
         self.languages = {
             'en': 'english',

--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -64,7 +64,7 @@ def parse_record(context, record, repos=None,
                 content = util.http_request('GET', record)
             except Exception as err:
                 raise RuntimeError('HTTP error: %s' % str(err))
-            return [_parse_dc(context, repos, etree.fromstring(content))]
+            return [_parse_dc(context, repos, etree.fromstring(content, context.parser))]
 
     elif mtype == 'urn:geoss:waf':  # WAF
         LOGGER.debug('WAF detected, fetching via HTTP')
@@ -109,7 +109,7 @@ def _parse_metadata(context, repos, record):
     """parse metadata formats"""
 
     if isinstance(record, str):
-        exml = etree.fromstring(record)
+        exml = etree.fromstring(record, context.parser)
     else:  # already serialized to lxml
         if hasattr(record, 'getroot'):  # standalone document
             exml = record.getroot()
@@ -225,10 +225,10 @@ def _parse_csw(context, repos, record, identifier, pagesize=10):
                 LOGGER.debug('Parsing metadata record: %s', v.xml)
                 if csw_typenames == 'gmd:MD_Metadata':
                     recobjs.append(_parse_iso(context, repos,
-                                              etree.fromstring(v.xml)))
+                                              etree.fromstring(v.xml, context.parser)))
                 else:
                     recobjs.append(_parse_dc(context, repos,
-                                             etree.fromstring(v.xml)))
+                                             etree.fromstring(v.xml, context.parser)))
             except Exception as err:  # parsing failed for some reason
                 LOGGER.warning('Metadata parsing failed %s', err)
 
@@ -244,7 +244,7 @@ def _parse_waf(context, repos, record, identifier):
 
     try:
         parser = etree.HTMLParser()
-        tree = etree.fromstring(content, parser=parser)
+        tree = etree.fromstring(content, parser)
     except Exception as err:
         raise Exception('Could not parse WAF: %s' % str(err))
         

--- a/pycsw/core/util.py
+++ b/pycsw/core/util.py
@@ -45,6 +45,9 @@ ranking_enabled = False
 ranking_pass = False
 ranking_query_geometry = ''
 
+
+PARSER = etree.XMLParser(resolve_entities=False)
+
 def get_today_and_now():
     """Get the date, right now, in ISO8601"""
     return time.strftime('%Y-%m-%dT%H:%M:%SZ', time.localtime())
@@ -263,7 +266,7 @@ def update_xpath(nsmap, xml, recprop):
     """Update XML document XPath values"""
 
     if isinstance(xml, unicode):  # not lxml serialized yet
-        xml = etree.fromstring(xml)
+        xml = etree.fromstring(xml, PARSER)
 
     recprop = eval(recprop)
     nsmap = eval(nsmap)
@@ -305,7 +308,7 @@ def get_anytext(bag):
         return ' '.join(filter(None, bag)).strip()
     else:  # xml
         if isinstance(bag, unicode) or isinstance(bag, str):  # not serialized yet
-            bag = etree.fromstring(bag)
+            bag = etree.fromstring(bag, PARSER)
             # get all XML element content
         return ' '.join([value.strip() for value in bag.xpath('//text()')])
 

--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -969,7 +969,7 @@ class Csw2(object):
                 if isinstance(resultset, etree._Comment):
                     searchresults.append(resultset)
                 for rec in resultset:
-                    searchresults.append(etree.fromstring(resultset[rec].xml), self.parent.context.parser)
+                    searchresults.append(etree.fromstring(resultset[rec].xml, self.parent.context.parser))
 
         if 'responsehandler' in self.parent.kvp:  # process the handler
             self.parent._process_responsehandler(etree.tostring(node,

--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -476,7 +476,7 @@ class Csw2(object):
                 path = os.path.join(self.parent.config.get('server', 'home'),
                 'core', 'schemas', 'ogc', 'csw', '2.0.2', 'record.xsd')
 
-                dublincore = etree.parse(path).getroot()
+                dublincore = etree.parse(path, self.parent.context.parser).getroot()
 
                 schemacomponent.append(dublincore)
 
@@ -969,7 +969,7 @@ class Csw2(object):
                 if isinstance(resultset, etree._Comment):
                     searchresults.append(resultset)
                 for rec in resultset:
-                    searchresults.append(etree.fromstring(resultset[rec].xml))
+                    searchresults.append(etree.fromstring(resultset[rec].xml), self.parent.context.parser)
 
         if 'responsehandler' in self.parent.kvp:  # process the handler
             self.parent._process_responsehandler(etree.tostring(node,
@@ -1032,7 +1032,7 @@ class Csw2(object):
             LOGGER.debug('GetRepositoryItem request.')
             if len(results) > 0:
                 return etree.fromstring(util.getqattr(results[0],
-                self.parent.context.md_core_model['mappings']['pycsw:XML']))
+                self.parent.context.md_core_model['mappings']['pycsw:XML']), self.parent.context.parser)
 
         for result in results:
             if (util.getqattr(result,
@@ -1429,7 +1429,7 @@ class Csw2(object):
             ['pycsw:Type']) != 'service'):
                 # dump record as is and exit
                 return etree.fromstring(util.getqattr(recobj,
-                self.parent.context.md_core_model['mappings']['pycsw:XML']))
+                self.parent.context.md_core_model['mappings']['pycsw:XML']), self.parent.context.parser)
 
             etree.SubElement(record,
             util.nspath_eval('dc:identifier', self.parent.context.namespaces)).text = \
@@ -1525,7 +1525,7 @@ class Csw2(object):
         request = {}
         try:
             LOGGER.debug('Parsing %s.' % postdata)
-            doc = etree.fromstring(postdata)
+            doc = etree.fromstring(postdata, self.parent.context.parser)
         except Exception as err:
             errortext = \
             'Exception: document not well-formed.\nError: %s.' % str(err)
@@ -1573,7 +1573,7 @@ class Csw2(object):
                     doc = etree.fromstring(postdata, parser)
                 LOGGER.debug('Request is valid XML.')
             else:  # parse Transaction without validation
-                doc = etree.fromstring(postdata)
+                doc = etree.fromstring(postdata, self.parent.context.parser)
         except Exception as err:
             errortext = \
             'Exception: the document is not valid.\nError: %s' % str(err)
@@ -1872,7 +1872,7 @@ class Csw2(object):
         node1 = etree.SubElement(node, util.nspath_eval('csw:EchoedRequest',
                 self.parent.context.namespaces))
         if self.parent.requesttype == 'POST':
-            node1.append(etree.fromstring(self.parent.request))
+            node1.append(etree.fromstring(self.parent.request, self.parent.context.parser))
         else:  # GET
             node2 = etree.SubElement(node1, util.nspath_eval('ows:Get',
                     self.parent.context.namespaces))

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -1013,7 +1013,7 @@ class Csw3(object):
 #                if isinstance(resultset, etree._Comment):
 #                    searchresults.append(resultset)
 #                for rec in resultset:
-#                    searchresults.append(etree.fromstring(resultset[rec].xml))
+#                    searchresults.append(etree.fromstring(resultset[rec].xml, self.parent.context.parser))
 
         searchresults.attrib['elapsedTime'] = get_elapsed_time(self.parent.process_time_start, time())
 
@@ -1094,7 +1094,7 @@ class Csw3(object):
             LOGGER.debug('GetRepositoryItem request.')
             if len(results) > 0:
                 return etree.fromstring(util.getqattr(results[0],
-                self.parent.context.md_core_model['mappings']['pycsw:XML']))
+                self.parent.context.md_core_model['mappings']['pycsw:XML']), self.parent.context.parser)
 
         for result in results:
             if (util.getqattr(result,
@@ -1500,7 +1500,7 @@ class Csw3(object):
             ['pycsw:Type']) != 'service'):
                 # dump record as is and exit
                 return etree.fromstring(util.getqattr(recobj,
-                self.parent.context.md_core_model['mappings']['pycsw:XML']))
+                self.parent.context.md_core_model['mappings']['pycsw:XML']), self.parent.context.parser)
 
             etree.SubElement(record,
             util.nspath_eval('dc:identifier', self.parent.context.namespaces)).text = \
@@ -1608,7 +1608,7 @@ class Csw3(object):
         request = {}
         try:
             LOGGER.debug('Parsing %s.' % postdata)
-            doc = etree.fromstring(postdata)
+            doc = etree.fromstring(postdata, self.parent.context.parser)
         except Exception as err:
             errortext = \
             'Exception: document not well-formed.\nError: %s.' % str(err)
@@ -1651,7 +1651,7 @@ class Csw3(object):
                     doc = etree.fromstring(postdata, parser)
                 LOGGER.debug('Request is valid XML.')
             else:  # parse Transaction without validation
-                doc = etree.fromstring(postdata)
+                doc = etree.fromstring(postdata, self.parent.context.parser)
         except Exception as err:
             errortext = \
             'Exception: the document is not valid.\nError: %s' % str(err)
@@ -1949,7 +1949,7 @@ class Csw3(object):
         node1 = etree.SubElement(node, util.nspath_eval('csw30:EchoedRequest',
                 self.parent.context.namespaces))
         if self.parent.requesttype == 'POST':
-            node1.append(etree.fromstring(self.parent.request))
+            node1.append(etree.fromstring(self.parent.request, self.parent.context.parser))
         else:  # GET
             node2 = etree.SubElement(node1, util.nspath_eval('ows:Get',
                     self.parent.context.namespaces))

--- a/pycsw/plugins/outputschemas/atom.py
+++ b/pycsw/plugins/outputschemas/atom.py
@@ -55,7 +55,7 @@ def write_record(result, esn, context, url=None):
 
     if esn == 'full' and typename == 'atom:entry':
         # dump record as is and exit
-        return etree.fromstring(util.getqattr(result, context.md_core_model['mappings']['pycsw:XML']))
+        return etree.fromstring(util.getqattr(result, context.md_core_model['mappings']['pycsw:XML']), context.parser)
 
     node = etree.Element(util.nspath_eval('atom:entry', NAMESPACES), nsmap=NAMESPACES)
     node.attrib[util.nspath_eval('xsi:schemaLocation', context.namespaces)] = \

--- a/pycsw/plugins/outputschemas/dif.py
+++ b/pycsw/plugins/outputschemas/dif.py
@@ -58,7 +58,7 @@ def write_record(result, esn, context, url=None):
 
     if esn == 'full' and typename == 'dif:DIF':
         # dump record as is and exit
-        return etree.fromstring(util.getqattr(result, context.md_core_model['mappings']['pycsw:XML']))
+        return etree.fromstring(util.getqattr(result, context.md_core_model['mappings']['pycsw:XML']), context.parser)
 
     node = etree.Element(util.nspath_eval('dif:DIF', NAMESPACES))
     node.attrib[util.nspath_eval('xsi:schemaLocation', context.namespaces)] = \

--- a/pycsw/plugins/outputschemas/fgdc.py
+++ b/pycsw/plugins/outputschemas/fgdc.py
@@ -59,7 +59,7 @@ def write_record(recobj, esn, context, url=None):
     typename = util.getqattr(recobj, context.md_core_model['mappings']['pycsw:Typename'])
     if esn == 'full' and typename == 'fgdc:metadata':
         # dump record as is and exit
-        return etree.fromstring(util.getqattr(recobj, context.md_core_model['mappings']['pycsw:XML']))
+        return etree.fromstring(util.getqattr(recobj, context.md_core_model['mappings']['pycsw:XML']), context.parser)
 
     node = etree.Element('metadata')
     node.attrib[util.nspath_eval('xsi:noNamespaceSchemaLocation', context.namespaces)] = \

--- a/pycsw/plugins/profiles/apiso/apiso.py
+++ b/pycsw/plugins/profiles/apiso/apiso.py
@@ -351,9 +351,12 @@ class APISO(profile.Profile):
         schemaLanguage='XMLSCHEMA', targetNamespace=self.namespace,
         parentSchema='gmd.xsd')
 
-        schema = etree.parse(os.path.join(self.context.pycsw_home,
-                 'plugins', 'profiles', 'apiso', 'schemas', 'ogc', 'iso',
-                 '19139', '20060504', 'gmd', 'identification.xsd')).getroot()
+        schema_file = os.path.join(self.context.pycsw_home, 'plugins',
+                                   'profiles', 'apiso', 'schemas', 'ogc',
+                                   'iso', '19139', '20060504', 'gmd',
+                                   'identification.xsd')
+
+        schema = etree.parse(schema_file, self.context.parser).getroot()
 
         node1.append(schema)
 
@@ -362,10 +365,12 @@ class APISO(profile.Profile):
         schemaLanguage='XMLSCHEMA', targetNamespace=self.namespace,
         parentSchema='gmd.xsd')
 
-        schema = etree.parse(os.path.join(self.context.pycsw_home,
-                 'plugins', 'profiles', 'apiso', 'schemas', 'ogc',
-                 'iso', '19139', '20060504', 'srv',
-                 'serviceMetadata.xsd')).getroot()
+        schema_file = os.path.join(self.context.pycsw_home, 'plugins',
+                                   'profiles', 'apiso', 'schemas', 'ogc',
+                                   'iso', '19139', '20060504', 'srv',
+                                   'serviceMetadata.xsd')
+
+        schema = etree.parse(schema_file, self.context.parser).getroot()
 
         node2.append(schema)
 
@@ -386,7 +391,7 @@ class APISO(profile.Profile):
 
         if (esn == 'full' and (typename == 'gmd:MD_Metadata' or is_iso_anyway)):
             # dump record as is and exit
-            return etree.fromstring(xml_blob)
+            return etree.fromstring(xml_blob, self.context.parser)
 
         if typename == 'csw:Record':  # transform csw:Record -> gmd:MD_Metadata model mappings
             util.transform_mappings(queryables, self.repository['mappings']['csw:Record'])

--- a/pycsw/plugins/profiles/ebrim/ebrim.py
+++ b/pycsw/plugins/profiles/ebrim/ebrim.py
@@ -105,10 +105,12 @@ class EBRIM(profile.Profile):
         util.nspath_eval('csw:SchemaComponent', self.context.namespaces),
         schemaLanguage='XMLSCHEMA', targetNamespace=self.namespace)
 
-        schema = etree.parse(os.path.join(self.context.pycsw_home,
-                 'plugins', 'profiles', 'ebrim',
-                 'schemas', 'ogc', 'csw', '2.0.2',
-                 'profiles', 'ebrim', '1.0', 'csw-ebrim.xsd')).getroot()
+        schema_file = os.path.join(self.context.pycsw_home, 'plugins',
+                                   'profiles', 'ebrim', 'schemas', 'ogc',
+                                   'csw', '2.0.2', 'profiles', 'ebrim',
+                                   '1.0', 'csw-ebrim.xsd')
+
+        schema = etree.parse(schema_file, self.context.parser).getroot()
 
         node.append(schema)
 
@@ -126,7 +128,7 @@ class EBRIM(profile.Profile):
 
         if esn == 'full' and typename == 'rim:RegistryObject':
             # dump record as is and exit
-            return etree.fromstring(util.getqattr(result, queryables['pycsw:XML']['dbcol']))
+            return etree.fromstring(util.getqattr(result, queryables['pycsw:XML']['dbcol']), self.context.parser)
 
         if typename == 'csw:Record':  # transform csw:Record -> rim:RegistryObject model mappings
             util.transform_mappings(queryables, self.repository['mappings']['csw:Record'])


### PR DESCRIPTION
This PR adds `pycsw.core.config.StaticContext.parser` as the central (non-validating and safe) parser most  `etree.fromstring` and `etree.parse` functions use.  Exceptions:

- validating parsers (created specific to context of request)
- 2 functions in `pycsw.util`, which are not associated. I believe the XML that gets to `pycsw.util` is already parsed, but added just in case