### PR TITLE
run unit tests  against Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
 
 after_script:
   - paver stop
+  - pycsw-admin.py -c get_sysprof
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: trusty
 
 sudo: false
 


### PR DESCRIPTION
# Overview
This PR updates pycsw's Travis-CI testing to run against Ubuntu Trusty (as opposed to default precise).

# Related Issue / Discussion
Per discussion w/ @kalxas on irc.

# Additional Information
https://docs.travis-ci.com/user/trusty-ci-environment/
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines

