### PR TITLE
normalize OpenSearch namespace declarations

### DIFF
--- a/pycsw/opensearch.py
+++ b/pycsw/opensearch.py
@@ -43,7 +43,6 @@ class OpenSearch(object):
         """initialize"""
 
         self.namespaces = {
-            None: 'http://a9.com/-/spec/opensearch/1.1/',
             'atom': 'http://www.w3.org/2005/Atom',
             'geo': 'http://a9.com/-/opensearch/extensions/geo/1.0/',
             'os': 'http://a9.com/-/spec/opensearch/1.1/',
@@ -51,8 +50,7 @@ class OpenSearch(object):
         }
 
         self.context = context
-        #self.context.namespaces.update(self.namespaces)
-
+        self.context.namespaces.update(self.namespaces)
 
     def response_csw2opensearch(self, element, cfg):
         """transform a CSW response into an OpenSearch response"""

--- a/tests/expected/suites_atom_get_opensearch-description.xml
+++ b/tests/expected/suites_atom_get_opensearch-description.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<OpenSearchDescription xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<OpenSearchDescription xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom">
   <ShortName>pycsw Geospatial Catalogue</ShortName>
   <LongName>pycsw Geospatial Catalogue</LongName>
   <Description>pycsw is an OGC CSW server implementation written in Python</Description>

--- a/tests/expected/suites_atom_get_opensearch-ogc-bbox-and-time.xml
+++ b/tests/expected/suites_atom_get_opensearch-ogc-bbox-and-time.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom">
   <atom:id>http://localhost/pycsw/csw.py?config=tests/suites/atom/default.cfg</atom:id>
   <atom:title>pycsw Geospatial Catalogue</atom:title>
   <os:totalResults>2</os:totalResults>

--- a/tests/expected/suites_atom_get_opensearch-ogc-bbox.xml
+++ b/tests/expected/suites_atom_get_opensearch-ogc-bbox.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom">
   <atom:id>http://localhost/pycsw/csw.py?config=tests/suites/atom/default.cfg</atom:id>
   <atom:title>pycsw Geospatial Catalogue</atom:title>
   <os:totalResults>3</os:totalResults>

--- a/tests/expected/suites_atom_get_opensearch-ogc-count-and-page1.xml
+++ b/tests/expected/suites_atom_get_opensearch-ogc-count-and-page1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom">
   <atom:id>http://localhost/pycsw/csw.py?config=tests/suites/atom/default.cfg</atom:id>
   <atom:title>pycsw Geospatial Catalogue</atom:title>
   <os:totalResults>2</os:totalResults>

--- a/tests/expected/suites_atom_get_opensearch-ogc-count-and-page2.xml
+++ b/tests/expected/suites_atom_get_opensearch-ogc-count-and-page2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom">
   <atom:id>http://localhost/pycsw/csw.py?config=tests/suites/atom/default.cfg</atom:id>
   <atom:title>pycsw Geospatial Catalogue</atom:title>
   <os:totalResults>2</os:totalResults>

--- a/tests/expected/suites_atom_get_opensearch-ogc-q-and-bbox.xml
+++ b/tests/expected/suites_atom_get_opensearch-ogc-q-and-bbox.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom">
   <atom:id>http://localhost/pycsw/csw.py?config=tests/suites/atom/default.cfg</atom:id>
   <atom:title>pycsw Geospatial Catalogue</atom:title>
   <os:totalResults>1</os:totalResults>

--- a/tests/expected/suites_atom_get_opensearch-ogc-q-and-time.xml
+++ b/tests/expected/suites_atom_get_opensearch-ogc-q-and-time.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom">
   <atom:id>http://localhost/pycsw/csw.py?config=tests/suites/atom/default.cfg</atom:id>
   <atom:title>pycsw Geospatial Catalogue</atom:title>
   <os:totalResults>1</os:totalResults>

--- a/tests/expected/suites_atom_get_opensearch-ogc-q.xml
+++ b/tests/expected/suites_atom_get_opensearch-ogc-q.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom">
   <atom:id>http://localhost/pycsw/csw.py?config=tests/suites/atom/default.cfg</atom:id>
   <atom:title>pycsw Geospatial Catalogue</atom:title>
   <os:totalResults>1</os:totalResults>

--- a/tests/expected/suites_atom_get_opensearch-ogc-time.xml
+++ b/tests/expected/suites_atom_get_opensearch-ogc-time.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom">
   <atom:id>http://localhost/pycsw/csw.py?config=tests/suites/atom/default.cfg</atom:id>
   <atom:title>pycsw Geospatial Catalogue</atom:title>
   <os:totalResults>1</os:totalResults>

--- a/tests/expected/suites_atom_get_opensearch-ogc-timeend.xml
+++ b/tests/expected/suites_atom_get_opensearch-ogc-timeend.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom">
   <atom:id>http://localhost/pycsw/csw.py?config=tests/suites/atom/default.cfg</atom:id>
   <atom:title>pycsw Geospatial Catalogue</atom:title>
   <os:totalResults>1</os:totalResults>

--- a/tests/expected/suites_atom_get_opensearch-ogc-timestart.xml
+++ b/tests/expected/suites_atom_get_opensearch-ogc-timestart.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom">
   <atom:id>http://localhost/pycsw/csw.py?config=tests/suites/atom/default.cfg</atom:id>
   <atom:title>pycsw Geospatial Catalogue</atom:title>
   <os:totalResults>3</os:totalResults>

--- a/tests/expected/suites_atom_get_opensearch.xml
+++ b/tests/expected/suites_atom_get_opensearch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<atom:feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom">
   <atom:id>http://localhost/pycsw/csw.py?config=tests/suites/atom/default.cfg</atom:id>
   <atom:title>pycsw Geospatial Catalogue</atom:title>
   <os:totalResults>12</os:totalResults>

--- a/tests/expected/suites_csw30_get_OpenSearch-description.xml
+++ b/tests/expected/suites_csw30_get_OpenSearch-description.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<OpenSearchDescription xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<OpenSearchDescription xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/" xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/" xmlns:atom="http://www.w3.org/2005/Atom">
   <ShortName>pycsw Geospatial</ShortName>
   <LongName>pycsw Geospatial Catalogue</LongName>
   <Description>pycsw is an OGC CSW server implementation written in Python</Description>


### PR DESCRIPTION
# Overview
This PR normalizes OpenSearch namespace declaration by removing using `None`/default/implicit namespacing in lxml.  The result is having more consolidated/consistent responses across lxml versions.

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines

