### PR TITLE
fix GetRecords DistributedSearch outputSchema handling (#413)

### DIFF
--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -836,7 +836,9 @@ class Csw2(object):
                 catalogue: %s.' % fedcat)
                 remotecsw = CatalogueServiceWeb(fedcat, skip_caps=True)
                 try:
-                    remotecsw.getrecords2(xml=self.parent.request)
+                    remotecsw.getrecords2(xml=self.parent.request,
+                                          esn=self.parent.kvp['elementsetname'],
+                                          outputschema=self.parent.kvp['outputschema'])
                     if hasattr(remotecsw, 'results'):
                         LOGGER.debug(
                         'Distributed search results from catalogue \

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -973,7 +973,9 @@ class Csw3(object):
                 try:
                     start_time = time()
                     remotecsw = CatalogueServiceWeb(fedcat, skip_caps=True)
-                    remotecsw.getrecords2(xml=self.parent.request)
+                    remotecsw.getrecords2(xml=self.parent.request,
+                                          esn=self.parent.kvp['elementsetname'],
+                                          outputschema=self.parent.kvp['outputschema'])
 
                     fsr = etree.SubElement(searchresults, util.nspath_eval(
                         'csw30:FederatedSearchResult',

--- a/tests/expected/suites_default_post_GetRecords-distributedsearch.xml
+++ b/tests/expected/suites_default_post_GetRecords-distributedsearch.xml
@@ -5,7 +5,7 @@
   <csw:SearchResults nextRecord="0" numberOfRecordsMatched="1" numberOfRecordsReturned="1" recordSchema="http://www.opengis.net/cat/csw/2.0.2" elementSet="brief">
     <!-- 1 result from http://demo.pycsw.org/gisdata/csw -->
     <csw:BriefRecord xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:ebrim="http://www.opengis.net/cat/wrs/1.0" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:inspire_ds="http://inspire.ec.europa.eu/schemas/inspire_ds/1.0" xmlns:wrs="http://www.opengis.net/cat/wrs/1.0" xmlns:apiso="http://www.opengis.net/cat/csw/apiso/1.0" xmlns:srv="http://www.isotc211.org/2005/srv">
-      <dc:identifier>urn:uuid:b0a1c48a-f765-11e1-bf69-aa0000ae6bfc</dc:identifier>
+      <dc:identifier>urn:uuid:dd87919a-e399-11e5-8327-aa0000ae6bfc</dc:identifier>
       <dc:title>Aquifers</dc:title>
       <dc:type>vector digital data</dc:type>
       <ows:BoundingBox crs="urn:x-ogc:def:crs:EPSG:6.11:4326" dimensions="2">


### PR DESCRIPTION
# Overview
This PR provides a safeguard for pycsw to explicitly set the `GetRecords` `elementsetname` and `outputschema` parameters during the `DistributedSearch` codepath.  The root fix has been made in https://github.com/geopython/OWSLib/commit/926ff61162df8fff9f97c1de7027a9daf98b4e24, so this PR ensures pycsw can, in addition, work against earlier versions OWSLib.

# Related Issue / Discussion
#413 
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines

