### PR TITLE
add allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 
 matrix:
   allow_failures:
-    - python: 3.4
+    - python: "3.4"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ dist: trusty
 python:
   - "2.6"
   - "2.7"
-#  - "3.4"
+  - "3.4"
+
+matrix:
+  allow_failures:
+    - python: 3.4
 
 addons:
   apt:


### PR DESCRIPTION
# Overview
This PR allows to run the tests in py3k without resulting in failure on the build per se.  This will help while we continue to implement/debug py3k support.  Thanks to @QuLogic for the recommendation.

# Related Issue / Discussion
NA
# Additional Information
NA
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines

