### PR TITLE
fix lxml warning

### DIFF
--- a/pycsw/opensearch.py
+++ b/pycsw/opensearch.py
@@ -395,7 +395,7 @@ def kvp2filterxml(kvp, context):
         if 'bbox' in kvp and kvp['bbox'] != '':
             LOGGER.debug('Adding bbox')
             root.append(bbox_element)
-        elif time_element:
+        elif time_element is not None:
             LOGGER.debug('Adding time')
             root.append(time_element)
         elif anytext_elements:


### PR DESCRIPTION
# Overview
Fix `FutureWarning` that is emitted when invoking the OpenSearch codepath.
# Related Issue / Discussion
To reproduce, run `paver test -s atom`.
# Additional Information
NA
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines

