### PR TITLE
Moving 1.10.x to geolinks 0.2.0 (#439)

### DIFF
--- a/pycsw/metadata.py
+++ b/pycsw/metadata.py
@@ -34,7 +34,7 @@ from urlparse import urlparse
 from lxml import etree
 from owslib.util import build_get_url
 from pycsw import util
-from geolinks.links import sniff_link
+from geolinks import sniff_link
 
 LOGGER = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-geolinks==0.0.1
+geolinks==0.2.0
 lxml==3.3.5
 OWSLib<0.9.0
 pyproj==1.9.3


### PR DESCRIPTION
# Overview
Since geolinks 0.2.0 has been uploaded to all major distributions, the next pycsw 1.10.x release should support this latest version of geolinks

# Related Issue / Discussion
https://github.com/geopython/pycsw/issues/439

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines

