### PR TITLE
fix test updates by adding pedantic flag from paver

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -180,6 +180,7 @@ def setup_testdata():
     ('database=', 'd', 'database (SQLite3 [default], PostgreSQL, MySQL)'),
     ('user=', 'U', 'database username'),
     ('pass=', 'p', 'database password'),
+    ('pedantic', 'P', 'run tests in pedantic mode (byte level diff check) (default: c14n mode)'),
     ('remote', 'r', 'remote testing (harvesting)'),
     ('time=', 't', 'time (milliseconds) in which requests should complete')
 ])
@@ -196,6 +197,7 @@ def test(options):
     database = options.get('database', 'SQLite3')
     remote = options.get('remote')
     timems = options.get('time', None)
+    pedantic = options.get('pedantic', False)
 
     if url is None:
         # run against default server
@@ -213,6 +215,9 @@ def test(options):
 
     if remote:
         cmd = '%s -r' % cmd
+
+    if pedantic:
+        cmd = '%s -p' % cmd
 
     if timems:
         cmd = '%s -t %s' % (cmd, timems)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -326,6 +326,8 @@ SYNOPSIS
 
     -s    testsuites to run (comma-seperated list)
 
+    -p    run tests in pedantic mode (byte level diff check) (default: c14n mode)
+
     -d    database (SQLite3 [default], PostgreSQL, MySQL)
 
     -r    run tests which harvest remote resources (default off)


### PR DESCRIPTION
# Overview
Adds a paver `-P` flag to run tests in pedantic mode.

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines

