### PR TITLE
Support overriding PYCSW_ROOT via environment variable.

### DIFF
--- a/pycsw/wsgi.py
+++ b/pycsw/wsgi.py
@@ -70,18 +70,23 @@ def application(env, start_response):
     if 'PYCSW_CONFIG' in env:
         config = env['PYCSW_CONFIG']
 
+    root = PYCSW_ROOT
+
+    if 'PYCSW_ROOT' in env:
+        root = env['PYCSW_ROOT']
+
     if env['QUERY_STRING'].lower().find('config') != -1:
         for kvp in env['QUERY_STRING'].split('&'):
             if kvp.lower().find('config') != -1:
                 config = unquote(kvp.split('=')[1])
 
     if not os.path.isabs(config):
-        config = os.path.join(PYCSW_ROOT, config)
+        config = os.path.join(root, config)
 
     if 'HTTP_HOST' in env and ':' in env['HTTP_HOST']:
         env['HTTP_HOST'] = env['HTTP_HOST'].split(':')[0]
 
-    env['local.app_root'] = PYCSW_ROOT
+    env['local.app_root'] = root
 
     csw = server.Csw(config, env)
 


### PR DESCRIPTION
# Overview

The relative path to the config files can differ between the build and installation environment, the parent directory of `wsgi.py` is not always the appropriate choice (it is to run the tests from the source directory).

The pycsw Debian package installs `wscgi.py` and the `tests` directory in `/usr/share/pycsw`,  and `tests/index.html` uses relative paths to the config files causing them not be found:
```
$ curl "http://localhost/pycsw/csw.py?config=tests/suites/sru/default.cfg&mode=sru" | tidy -xml -i -w -q
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   859  100   859    0     0   145k      0 --:--:-- --:--:-- --:--:--  167k
<?xml version="1.0" encoding="utf-8" standalone="no"?>
<!-- pycsw 2.0.0 -->
<ows20:ExceptionReport xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:ows20="http://www.opengis.net/ows/2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/2.0 http://schemas.opengis.net/ows/2.0/owsExceptionReport.xsd">
  <ows20:Exception exceptionCode="NoApplicableCode" locator="service">
    <ows20:ExceptionText>Error opening configuration /usr/share/tests/suites/sru/default.cfg</ows20:ExceptionText>
  </ows20:Exception>
</ows20:ExceptionReport>
```

Overriding the default `PYCSW_ROOT` via the environment variable in the Apache configuration allows the tests to work with the Debian package setup too:
```
$ cat debian/pycsw.conf 
WSGIScriptAlias /pycsw /usr/share/pycsw/wsgi.py
Alias /pycsw/tests /usr/share/pycsw/tests

<LocationMatch /pycsw>
  Options +FollowSymLinks 
  Require all granted
  SetEnv PYCSW_ROOT /usr/share/pycsw
</LocationMatch>
```
```
$ curl "http://localhost/pycsw/csw.py?config=tests/suites/sru/default.cfg&mode=sru" 2>&1 | head
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!-- pycsw 2.0.0 -->
<sru:explainResponse xmlns:sru="http://www.loc.gov/zing/srw/" xmlns:zr="http://explain.z3950.org/dtd/2.1/">
  <sru:version>1.1</sru:version>
  <sru:record>
    <sru:recordPacking>XML</sru:recordPacking>
    <sru:recordSchema>http://explain.z3950.org/dtd/2.1/</sru:recordSchema>
    <sru:recordData>
```

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute my changes to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines

