### PR TITLE
Fix desktop file validation error.

### DIFF
--- a/etc/pycsw.desktop
+++ b/etc/pycsw.desktop
@@ -3,7 +3,6 @@ Type=Application
 Encoding=UTF-8
 Name=pycsw
 Comment=pycsw catalog server
-Categories=Application;Education;Geography;
 Exec=firefox http://localhost/pycsw/tests/index.html
 Icon=/var/www/html/pycsw/docs/_static/pycsw-logo.png
 Terminal=false


### PR DESCRIPTION
`desktop-file-validate` reported:
```
etc/pycsw.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
etc/pycsw.desktop: error: file contains multiple keys named "Categories" in group "Desktop Entry"
etc/pycsw.desktop: warning: value "Application;Education;Geography;" for key "Categories" in group "Desktop Entry" contains a deprecated value "Application"
```
The duplicate "Categories" key with the deprecated "Application" value is removed.