### PR TITLE
Include dct:alternative in csw3  full output

### DIFF
--- a/pycsw/core/config.py
+++ b/pycsw/core/config.py
@@ -289,6 +289,8 @@ class StaticContext(object):
                                 # map Dublin Core queryables to core metadata model
                                 'dc:title':
                                 {'dbcol': self.md_core_model['mappings']['pycsw:Title']},
+                                'dct:alternative':
+                                {'dbcol': self.md_core_model['mappings']['pycsw:AlternateTitle']},
                                 'dc:creator':
                                 {'dbcol': self.md_core_model['mappings']['pycsw:Creator']},
                                 'dc:subject':
@@ -318,6 +320,8 @@ class StaticContext(object):
                                 'dc:rights':
                                 {'dbcol':
                                  self.md_core_model['mappings']['pycsw:AccessConstraints']},
+                                'dct:spatial':
+                                {'dbcol': self.md_core_model['mappings']['pycsw:CRS']},
                                 # bbox and full text map to internal fixed columns
                                 'ows:BoundingBox':
                                 {'dbcol': self.md_core_model['mappings']['pycsw:BoundingBox']},
@@ -502,6 +506,8 @@ class StaticContext(object):
                                 # map Dublin Core queryables to core metadata model
                                 'dc:title':
                                 {'dbcol': self.md_core_model['mappings']['pycsw:Title']},
+                                'dct:alternative':
+                                {'dbcol': self.md_core_model['mappings']['pycsw:AlternateTitle']},
                                 'dc:creator':
                                 {'dbcol': self.md_core_model['mappings']['pycsw:Creator']},
                                 'dc:subject':
@@ -531,6 +537,8 @@ class StaticContext(object):
                                 'dc:rights':
                                 {'dbcol':
                                  self.md_core_model['mappings']['pycsw:AccessConstraints']},
+                                'dct:spatial':
+                                {'dbcol': self.md_core_model['mappings']['pycsw:CRS']},
                                 # bbox and full text map to internal fixed columns
                                 'ows:BoundingBox':
                                 {'dbcol': self.md_core_model['mappings']['pycsw:BoundingBox']},
@@ -567,6 +575,7 @@ class StaticContext(object):
 
         defaults = {
             'dc:title': 'pycsw:Title',
+            'dct:alternative': 'pycsw:AlternateTitle',
             'dc:creator': 'pycsw:Creator',
             'dc:subject': 'pycsw:Keywords',
             'dct:abstract': 'pycsw:Abstract',
@@ -581,6 +590,7 @@ class StaticContext(object):
             'dc:language': 'pycsw:Language',
             'dc:relation': 'pycsw:Relation',
             'dc:rights': 'pycsw:AccessConstraints',
+            'dct:spatial': 'pycsw:CRS',
             'ows:BoundingBox': 'pycsw:BoundingBox',
             'csw:AnyText': 'pycsw:AnyText',
         }

--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -1511,11 +1511,15 @@ class Csw2(object):
             if self.parent.kvp['elementsetname'] == 'full':  # add full elements
                 for i in ['dc:date', 'dc:creator', \
                 'dc:publisher', 'dc:contributor', 'dc:source', \
-                'dc:language', 'dc:rights']:
+                'dc:language', 'dc:rights', 'dct:alternative']:
                     val = util.getqattr(recobj, queryables[i]['dbcol'])
                     if val:
                         etree.SubElement(record,
                         util.nspath_eval(i, self.parent.context.namespaces)).text = val
+                val = util.getqattr(recobj, queryables['dct:spatial']['dbcol'])
+                if val:
+                    etree.SubElement(record,
+                    util.nspath_eval('dct:spatial', self.parent.context.namespaces), scheme='http://www.opengis.net/def/crs').text = val
 
             # always write out ows:BoundingBox
             bboxel = write_boundingbox(getattr(recobj,

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -1585,6 +1585,10 @@ class Csw3(object):
                     if val:
                         etree.SubElement(record,
                         util.nspath_eval(i, self.parent.context.namespaces)).text = val
+                val = util.getqattr(recobj, queryables['dct:spatial']['dbcol'])
+                if val:
+                    etree.SubElement(record,
+                    util.nspath_eval('dct:spatial', self.parent.context.namespaces), scheme='http://www.opengis.net/def/crs').text = val
 
             # always write out ows:BoundingBox
             bboxel = write_boundingbox(getattr(recobj,

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -1580,7 +1580,7 @@ class Csw3(object):
             if self.parent.kvp['elementsetname'] == 'full':  # add full elements
                 for i in ['dc:date', 'dc:creator', \
                 'dc:publisher', 'dc:contributor', 'dc:source', \
-                'dc:language', 'dc:rights']:
+                'dc:language', 'dc:rights', 'dct:alternative']:
                     val = util.getqattr(recobj, queryables[i]['dbcol'])
                     if val:
                         etree.SubElement(record,

--- a/tests/expected/suites_apiso-inspire_get_GetCapabilities-lang.xml
+++ b/tests/expected/suites_apiso-inspire_get_GetCapabilities-lang.xml
@@ -169,7 +169,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
       <ows:Constraint name="SupportedISOQueryables">

--- a/tests/expected/suites_apiso-inspire_get_GetCapabilities.xml
+++ b/tests/expected/suites_apiso-inspire_get_GetCapabilities.xml
@@ -169,7 +169,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
       <ows:Constraint name="SupportedISOQueryables">

--- a/tests/expected/suites_apiso_post_GetCapabilities.xml
+++ b/tests/expected/suites_apiso_post_GetCapabilities.xml
@@ -169,7 +169,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
       <ows:Constraint name="SupportedISOQueryables">

--- a/tests/expected/suites_atom_post_GetCapabilities.xml
+++ b/tests/expected/suites_atom_post_GetCapabilities.xml
@@ -150,7 +150,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>

--- a/tests/expected/suites_cite_get_27e17158-c57a-4493-92ac-dba8934cf462.xml
+++ b/tests/expected/suites_cite_get_27e17158-c57a-4493-92ac-dba8934cf462.xml
@@ -152,7 +152,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>

--- a/tests/expected/suites_cite_get_2ab7d1fa-885b-459f-80e4-b6282eab4f8c.xml
+++ b/tests/expected/suites_cite_get_2ab7d1fa-885b-459f-80e4-b6282eab4f8c.xml
@@ -152,7 +152,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>

--- a/tests/expected/suites_cite_get_477b23a3-baa9-47c8-9541-5fe27735ed49.xml
+++ b/tests/expected/suites_cite_get_477b23a3-baa9-47c8-9541-5fe27735ed49.xml
@@ -269,7 +269,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_cite_get_48f26761-3a9d-48db-bee1-da089f5fb857.xml
+++ b/tests/expected/suites_cite_get_48f26761-3a9d-48db-bee1-da089f5fb857.xml
@@ -152,7 +152,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>

--- a/tests/expected/suites_cite_get_55c38f00-2553-42c1-99ab-33edbb561ad7.xml
+++ b/tests/expected/suites_cite_get_55c38f00-2553-42c1-99ab-33edbb561ad7.xml
@@ -243,7 +243,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_cite_get_80f31def-4185-48b9-983a-960566918eae.xml
+++ b/tests/expected/suites_cite_get_80f31def-4185-48b9-983a-960566918eae.xml
@@ -269,7 +269,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_cite_get_9697f0aa-3b6a-4125-83a5-61e8826127c4.xml
+++ b/tests/expected/suites_cite_get_9697f0aa-3b6a-4125-83a5-61e8826127c4.xml
@@ -269,7 +269,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_cite_get_ba5fc729-3b71-47a0-b7d0-42ec565cd185.xml
+++ b/tests/expected/suites_cite_get_ba5fc729-3b71-47a0-b7d0-42ec565cd185.xml
@@ -152,7 +152,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>

--- a/tests/expected/suites_cite_get_f4692ec5-9547-4a05-88ab-e6154af2640a.xml
+++ b/tests/expected/suites_cite_get_f4692ec5-9547-4a05-88ab-e6154af2640a.xml
@@ -152,7 +152,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>

--- a/tests/expected/suites_csw30_get_0bdf8457-971e-4ed1-be4a-5feca4dcd8fa.xml
+++ b/tests/expected/suites_csw30_get_0bdf8457-971e-4ed1-be4a-5feca4dcd8fa.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_22f44168-2ccf-4801-ad96-204212566d56.xml
+++ b/tests/expected/suites_csw30_get_22f44168-2ccf-4801-ad96-204212566d56.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_2499a9c9-8d33-449c-bc92-d494adfcc84d.xml
+++ b/tests/expected/suites_csw30_get_2499a9c9-8d33-449c-bc92-d494adfcc84d.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_27f4f39c-d92a-4e3c-b961-c6aa8c24e513.xml
+++ b/tests/expected/suites_csw30_get_27f4f39c-d92a-4e3c-b961-c6aa8c24e513.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_2b06a5c8-0df2-4af1-8d2e-a425de11c845.xml
+++ b/tests/expected/suites_csw30_get_2b06a5c8-0df2-4af1-8d2e-a425de11c845.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_43cd6471-6ac7-45bd-8ff9-148cb2de9a52.xml
+++ b/tests/expected/suites_csw30_get_43cd6471-6ac7-45bd-8ff9-148cb2de9a52.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_5e9e67dc-18d6-4645-8111-c6263c88a61f.xml
+++ b/tests/expected/suites_csw30_get_5e9e67dc-18d6-4645-8111-c6263c88a61f.xml
@@ -177,7 +177,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_6a9d0558-9d87-495b-b999-b49a3ef1cf99.xml
+++ b/tests/expected/suites_csw30_get_6a9d0558-9d87-495b-b999-b49a3ef1cf99.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_6e9cba43-5e27-415d-adbd-a92851c2c173.xml
+++ b/tests/expected/suites_csw30_get_6e9cba43-5e27-415d-adbd-a92851c2c173.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_7e82446a-b5dc-43fe-9a73-4cc1f2f2f0bf.xml
+++ b/tests/expected/suites_csw30_get_7e82446a-b5dc-43fe-9a73-4cc1f2f2f0bf.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_8025978e-1a35-4d70-80c2-e8329e0c7864.xml
+++ b/tests/expected/suites_csw30_get_8025978e-1a35-4d70-80c2-e8329e0c7864.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_GetCapabilities-base-url.xml
+++ b/tests/expected/suites_csw30_get_GetCapabilities-base-url.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_GetCapabilities-no-version.xml
+++ b/tests/expected/suites_csw30_get_GetCapabilities-no-version.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_GetCapabilities.xml
+++ b/tests/expected/suites_csw30_get_GetCapabilities.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_c03d173a-3f42-4956-89c8-1fe02c3a0873.xml
+++ b/tests/expected/suites_csw30_get_c03d173a-3f42-4956-89c8-1fe02c3a0873.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_get_e67ca935-d65d-4d8c-8302-1405333dded0.xml
+++ b/tests/expected/suites_csw30_get_e67ca935-d65d-4d8c-8302-1405333dded0.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_csw30_post_GetCapabilities.xml
+++ b/tests/expected/suites_csw30_post_GetCapabilities.xml
@@ -217,7 +217,9 @@
         <ows20:Value>dc:title</ows20:Value>
         <ows20:Value>dc:type</ows20:Value>
         <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
         <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
         <ows20:Value>ows:BoundingBox</ows20:Value>
       </ows20:AllowedValues>
     </ows20:Constraint>

--- a/tests/expected/suites_default_get_GetCapabilities.xml
+++ b/tests/expected/suites_default_get_GetCapabilities.xml
@@ -150,7 +150,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>

--- a/tests/expected/suites_default_post_GetCapabilities-SOAP.xml
+++ b/tests/expected/suites_default_post_GetCapabilities-SOAP.xml
@@ -152,7 +152,9 @@
             <ows:Value>dc:title</ows:Value>
             <ows:Value>dc:type</ows:Value>
             <ows:Value>dct:abstract</ows:Value>
+            <ows:Value>dct:alternative</ows:Value>
             <ows:Value>dct:modified</ows:Value>
+            <ows:Value>dct:spatial</ows:Value>
             <ows:Value>ows:BoundingBox</ows:Value>
           </ows:Constraint>
         </ows:Operation>

--- a/tests/expected/suites_default_post_GetCapabilities-updatesequence.xml
+++ b/tests/expected/suites_default_post_GetCapabilities-updatesequence.xml
@@ -150,7 +150,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>

--- a/tests/expected/suites_default_post_GetCapabilities.xml
+++ b/tests/expected/suites_default_post_GetCapabilities.xml
@@ -150,7 +150,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>

--- a/tests/expected/suites_dif_post_GetCapabilities.xml
+++ b/tests/expected/suites_dif_post_GetCapabilities.xml
@@ -150,7 +150,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>

--- a/tests/expected/suites_ebrim_post_GetCapabilities.xml
+++ b/tests/expected/suites_ebrim_post_GetCapabilities.xml
@@ -153,7 +153,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>

--- a/tests/expected/suites_fgdc_post_GetCapabilities.xml
+++ b/tests/expected/suites_fgdc_post_GetCapabilities.xml
@@ -150,7 +150,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>

--- a/tests/expected/suites_gm03_post_GetCapabilities.xml
+++ b/tests/expected/suites_gm03_post_GetCapabilities.xml
@@ -150,7 +150,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>

--- a/tests/expected/suites_manager_post_GetCapabilities.xml
+++ b/tests/expected/suites_manager_post_GetCapabilities.xml
@@ -171,7 +171,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
       <ows:Constraint name="SupportedISOQueryables">

--- a/tests/expected/suites_utf-8_post_GetCapabilities.xml
+++ b/tests/expected/suites_utf-8_post_GetCapabilities.xml
@@ -150,7 +150,9 @@
         <ows:Value>dc:title</ows:Value>
         <ows:Value>dc:type</ows:Value>
         <ows:Value>dct:abstract</ows:Value>
+        <ows:Value>dct:alternative</ows:Value>
         <ows:Value>dct:modified</ows:Value>
+        <ows:Value>dct:spatial</ows:Value>
         <ows:Value>ows:BoundingBox</ows:Value>
       </ows:Constraint>
     </ows:Operation>


### PR DESCRIPTION
# Overview
We are setting up a system that configures mapproxy for CSW records. This piece of information is needed in CSW output in order to correctly configure mapproxy.

# Related Issue / Discussion

# Additional Information
Since the standard does not define exactly what goes in full, it should be okay to add this item if it is set in the database.

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines

This is needed to be able to share the WMS layer name between CSW services.