### PR TITLE
Removed redundant &&

### DIFF
--- a/pycsw/opensearch.py
+++ b/pycsw/opensearch.py
@@ -192,7 +192,7 @@ class OpenSearch(object):
             # Requirement-023
             node1 = etree.SubElement(node, util.nspath_eval('os:Url', self.namespaces))
             node1.set('type', 'application/atom+xml')
-            node1.set('template', '%smode=opensearch&service=CSW&version=3.0.0&request=GetRecords&elementsetname=full&typenames=csw:Record&resulttype=results&q={searchTerms?}&bbox={geo:box?}&time={time:start?}/{time:end?}&outputformat=application/atom%%2Bxml&&startposition={startIndex?}&maxrecords={count?}&recordids={geo:uid}' % self.bind_url)
+            node1.set('template', '%smode=opensearch&service=CSW&version=3.0.0&request=GetRecords&elementsetname=full&typenames=csw:Record&resulttype=results&q={searchTerms?}&bbox={geo:box?}&time={time:start?}/{time:end?}&outputformat=application/atom%%2Bxml&startposition={startIndex?}&maxrecords={count?}&recordids={geo:uid}' % self.bind_url)
 
             node1 = etree.SubElement(node, util.nspath_eval('os:Image', self.namespaces))
             node1.set('type', 'image/vnd.microsoft.icon')

--- a/tests/functionaltests/suites/csw30/expected/get_002258f0-627f-457f-b2ad-025777c77ac8.xml
+++ b/tests/functionaltests/suites/csw30/expected/get_002258f0-627f-457f-b2ad-025777c77ac8.xml
@@ -6,7 +6,7 @@
   <os:Description>pycsw is an OGC CSW server implementation written in Python</os:Description>
   <os:Tags>catalogue discovery</os:Tags>
   <os:Url type="application/xml" template="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg&amp;service=CSW&amp;version=3.0.0&amp;request=GetRecords&amp;elementsetname=full&amp;typenames=csw:Record&amp;resulttype=results&amp;q={searchTerms?}&amp;bbox={geo:box?}&amp;time={time:start?}/{time:end?}&amp;outputformat=application/xml&amp;outputschema=http://www.opengis.net/cat/csw/3.0&amp;startposition={startIndex?}&amp;maxrecords={count?}&amp;recordids={geo:uid}"/>
-  <os:Url type="application/atom+xml" template="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg&amp;mode=opensearch&amp;service=CSW&amp;version=3.0.0&amp;request=GetRecords&amp;elementsetname=full&amp;typenames=csw:Record&amp;resulttype=results&amp;q={searchTerms?}&amp;bbox={geo:box?}&amp;time={time:start?}/{time:end?}&amp;outputformat=application/atom%2Bxml&amp;&amp;startposition={startIndex?}&amp;maxrecords={count?}&amp;recordids={geo:uid}"/>
+  <os:Url type="application/atom+xml" template="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg&amp;mode=opensearch&amp;service=CSW&amp;version=3.0.0&amp;request=GetRecords&amp;elementsetname=full&amp;typenames=csw:Record&amp;resulttype=results&amp;q={searchTerms?}&amp;bbox={geo:box?}&amp;time={time:start?}/{time:end?}&amp;outputformat=application/atom%2Bxml&amp;startposition={startIndex?}&amp;maxrecords={count?}&amp;recordids={geo:uid}"/>
   <os:Image type="image/vnd.microsoft.icon" width="16" height="16">http://pycsw.org/img/favicon.ico</os:Image>
   <os:Query role="example" geo:box="-180,-90,180,90"/>
   <os:Developer>Kralidis, Tom</os:Developer>

--- a/tests/functionaltests/suites/csw30/expected/get_OpenSearch-description.xml
+++ b/tests/functionaltests/suites/csw30/expected/get_OpenSearch-description.xml
@@ -6,7 +6,7 @@
   <os:Description>pycsw is an OGC CSW server implementation written in Python</os:Description>
   <os:Tags>catalogue discovery</os:Tags>
   <os:Url type="application/xml" template="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg&amp;service=CSW&amp;version=3.0.0&amp;request=GetRecords&amp;elementsetname=full&amp;typenames=csw:Record&amp;resulttype=results&amp;q={searchTerms?}&amp;bbox={geo:box?}&amp;time={time:start?}/{time:end?}&amp;outputformat=application/xml&amp;outputschema=http://www.opengis.net/cat/csw/3.0&amp;startposition={startIndex?}&amp;maxrecords={count?}&amp;recordids={geo:uid}"/>
-  <os:Url type="application/atom+xml" template="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg&amp;mode=opensearch&amp;service=CSW&amp;version=3.0.0&amp;request=GetRecords&amp;elementsetname=full&amp;typenames=csw:Record&amp;resulttype=results&amp;q={searchTerms?}&amp;bbox={geo:box?}&amp;time={time:start?}/{time:end?}&amp;outputformat=application/atom%2Bxml&amp;&amp;startposition={startIndex?}&amp;maxrecords={count?}&amp;recordids={geo:uid}"/>
+  <os:Url type="application/atom+xml" template="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg&amp;mode=opensearch&amp;service=CSW&amp;version=3.0.0&amp;request=GetRecords&amp;elementsetname=full&amp;typenames=csw:Record&amp;resulttype=results&amp;q={searchTerms?}&amp;bbox={geo:box?}&amp;time={time:start?}/{time:end?}&amp;outputformat=application/atom%2Bxml&amp;startposition={startIndex?}&amp;maxrecords={count?}&amp;recordids={geo:uid}"/>
   <os:Image type="image/vnd.microsoft.icon" width="16" height="16">http://pycsw.org/img/favicon.ico</os:Image>
   <os:Query role="example" geo:box="-180,-90,180,90"/>
   <os:Developer>Kralidis, Tom</os:Developer>


### PR DESCRIPTION
The template URI contains a un superfluous "&" character. 
The double "&&" causes some issues with our automated tests

# Overview

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
