### PR TITLE
fix exception name spelling

### DIFF
--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -194,7 +194,7 @@ class Csw(object):
                 self.context.refresh_dc(mappings.MD_CORE_MODEL)
             except Exception as err:
                 self.response = self.iface.exceptionreport(
-                    'NoAppliicableCode', 'service',
+                    'NoApplicableCode', 'service',
                     'Could not load repository.mappings %s' % str(err)
                 )
 


### PR DESCRIPTION
# Overview
Fixed an apparent exception name spelling problem.

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute this bugfix to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
