### PR TITLE
Fix broken links

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,7 +3,7 @@ Contributing to pycsw
 
 The pycsw project openly welcomes contributions (bug reports, bug fixes, code
 enhancements/features, etc.).  This document will outline some guidelines on
-contributing to pycsw.  As well, the pycsw `community </community.html>`_ is a great place to
+contributing to pycsw.  As well, the pycsw `community <http://pycsw.org/community/>`_ is a great place to
 get an idea of how to connect and participate in pycsw community and development.
 
 pycsw has the following modes of contribution:
@@ -147,4 +147,4 @@ your own repository to ensure your pycsw repository is up to date with pycsw mas
 .. _`pylint`: http://www.logilab.org/857
 .. _`Sphinx`: http://sphinx-doc.org/
 .. _`developer tasks`: https://github.com/geopython/pycsw/wiki/Developer-Tasks
-.. _`mailing list`: http://pycsw.org/community.html#mailing_list
+.. _`mailing list`: http://pycsw.org/community#mailing-list


### PR DESCRIPTION
# Overview
   - Fix the broken links to community page on CONTRIBUTING.rst

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
