### PR TITLE
Issue 508 read pycsw config from env

### DIFF
--- a/pycsw/wsgi.py
+++ b/pycsw/wsgi.py
@@ -56,7 +56,9 @@
 
 import os
 import sys
+
 import six
+from six.moves import configparser
 from six.moves.urllib.parse import unquote
 
 from pycsw import server
@@ -65,90 +67,125 @@ from pycsw import server
 def application(env, start_response):
     """WSGI wrapper"""
 
-    pycsw_root = get_pycsw_root_path(env)
+    pycsw_root = get_pycsw_root_path(os.environ, env)
+    configuration_path = get_configuration_path(os.environ, env, pycsw_root)
     env['local.app_root'] = pycsw_root
-    configuration_path = get_configuration_path(env, pycsw_root)
     if 'HTTP_HOST' in env and ':' in env['HTTP_HOST']:
         env['HTTP_HOST'] = env['HTTP_HOST'].split(':')[0]
     csw = server.Csw(configuration_path, env)
-    gzip = False
-    if ('HTTP_ACCEPT_ENCODING' in env and
-            env['HTTP_ACCEPT_ENCODING'].find('gzip') != -1):
-        # set for gzip compressed response
-        gzip = True
-    # set compression level
-    if csw.config.has_option('server', 'gzip_compresslevel'):
-        gzip_compresslevel = \
-            int(csw.config.get('server', 'gzip_compresslevel'))
-    else:
-        gzip_compresslevel = 0
     status, contents = csw.dispatch_wsgi()
-    headers = {}
-    if gzip and gzip_compresslevel > 0:
-        import gzip
-        buf = six.BytesIO()
-        gzipfile = gzip.GzipFile(mode='wb', fileobj=buf,
-                                 compresslevel=gzip_compresslevel)
-        gzipfile.write(contents)
-        gzipfile.close()
-        contents = buf.getvalue()
-        headers['Content-Encoding'] = 'gzip'
-    headers['Content-Length'] = str(len(contents))
-    headers['Content-Type'] = str(csw.contenttype)
+    headers = {
+        'Content-Length': str(len(contents)),
+        'Content-Type': str(csw.contenttype)
+    }
+    if "gzip" in env.get("HTTP_ACCEPT_ENCODING", ""):
+        try:
+            compression_level = int(
+                csw.config.get("server", "gzip_compresslevel"))
+            contents, compress_headers = compress_response(
+                contents, compression_level)
+            headers.update(compress_headers)
+        except configparser.NoOptionError:
+            print(
+                "The client requested a gzip compressed response. However, "
+                "the server does not specify the 'gzip_compresslevel' option. "
+                "Returning an uncompressed response..."
+            )
     start_response(status, list(headers.items()))
     return [contents]
 
 
-def get_pycsw_root_path(request_environment, root_path_key="PYCSW_ROOT"):
-    """Get pycsw's root path
-    
+def compress_response(response, compression_level):
+    """Compress pycsw's response with gzip
+
     Parameters
     ----------
-    request_environment: dict
-        A mapping with the request's environment. Typically the WSGI's 
-        environment 
+    response: str
+        The already processed CSW request
+    compression_level: int
+        Level of compression to use in gzip algorithm
+
+    Returns
+    -------
+    bytes
+        The full binary contents of the compressed response
+    dict
+        Extra HTTP headers that are useful for the response
+
+    """
+
+    import gzip
+    buf = six.BytesIO()
+    gzipfile = gzip.GzipFile(mode='wb', fileobj=buf,
+                             compresslevel=compression_level)
+    gzipfile.write(response)
+    gzipfile.close()
+    compressed_response = buf.getvalue()
+    compression_headers = {'Content-Encoding': 'gzip'}
+    return compressed_response, compression_headers
+
+
+def get_pycsw_root_path(process_environment, request_environment=None,
+                        root_path_key="PYCSW_ROOT"):
+    """Get pycsw's root path.
+
+    The root path will be searched in the ``process_environment`` first, then
+    in the ``request_environment``. If it cannot be found then it is determined
+    based on the location on disk.
+
+    Parameters
+    ----------
+    process_environment: dict
+        A mapping with the process environment.
+    request_environment: dict, optional
+        A mapping with the request environment. Typically the WSGI's
+        environment
     root_path_key: str
-        Name of the key in both the ``request_environment`` argument and the
-        process' environmental variables that specifies the path to pycsw's 
+        Name of the key in both the ``process_environment`` and the
+        ``request_environment`` parameters that specifies the path to pycsw's
         root path.
-         
+
     Returns
     -------
     str
         Path to pycsw's root path, as read from the supplied configuration.
-    
+
     """
 
-    app_root = os.getenv(
+    req_env = (
+        dict(request_environment) if request_environment is not None else {})
+    app_root = process_environment.get(
         root_path_key,
-        request_environment.get(root_path_key)
+        req_env.get(
+            root_path_key,
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
     )
-    if app_root is None:
-        app_root = os.path.dirname(
-            os.path.dirname(os.path.abspath(__file__)))
     return app_root
 
 
-def get_configuration_path(request_environment, pycsw_root,
-                           config_path_key="PYCSW_CONFIG"):
+def get_configuration_path(process_environment, request_environment,
+                           pycsw_root, config_path_key="PYCSW_CONFIG"):
     """Get the path for pycsw configuration file.
 
     The configuration file path is searched in the following:
-    * The presence of a `config` parameter in the request's query string;
-    * A `PYCSW_CONFIG` environment variable;
-    * A `PYCSW_CONFIG WSGI variable.
-    
+    * The presence of a ``config`` parameter in the request's query string;
+    * A ``PYCSW_CONFIG`` environment variable;
+    * A ``PYCSW_CONFIG`` WSGI variable.
+
     Parameters
     ----------
+    process_environment: dict
+        A mapping with the process environment.
     request_environment: dict
-        A mapping with the request's environment. Typically the WSGI's 
-        environment 
+        A mapping with the request's environment. Typically the WSGI's
+        environment
     pycsw_root: str
         pycsw's default root path
     config_path_key: str, optional
-        Name of the variable that specifies the path to pycsw's configuration 
+        Name of the variable that specifies the path to pycsw's configuration
         file.
-        
+
     Returns
     -------
     str
@@ -156,13 +193,13 @@ def get_configuration_path(request_environment, pycsw_root,
 
     """
 
-    query_string = request_environment["QUERY_STRING"].lower()
+    query_string = request_environment.get("QUERY_STRING", "").lower()
     for kvp in query_string.split('&'):
         if "config" in kvp:
             configuration_path = unquote(kvp.split('=')[1])
             break
     else:  # did not find any `config` parameter in the request
-        configuration_path = os.getenv(
+        configuration_path = process_environment.get(
             config_path_key,
             request_environment.get(config_path_key, "")
         )
@@ -177,5 +214,5 @@ if __name__ == '__main__':  # run inline using WSGI reference implementation
     if len(sys.argv) > 1:
         port = int(sys.argv[1])
     httpd = make_server('', port, application)
-    print('Serving on port %d...' % port)
+    print('Serving on port {}...'.format(port))
     httpd.serve_forever()

--- a/pycsw/wsgi.py
+++ b/pycsw/wsgi.py
@@ -100,6 +100,25 @@ def application(env, start_response):
 
 
 def get_pycsw_root_path(request_environment, root_path_key="PYCSW_ROOT"):
+    """Get pycsw's root path
+    
+    Parameters
+    ----------
+    request_environment: dict
+        A mapping with the request's environment. Typically the WSGI's 
+        environment 
+    root_path_key: str
+        Name of the key in both the ``request_environment`` argument and the
+        process' environmental variables that specifies the path to pycsw's 
+        root path.
+         
+    Returns
+    -------
+    str
+        Path to pycsw's root path, as read from the supplied configuration.
+    
+    """
+
     app_root = os.getenv(
         root_path_key,
         request_environment.get(root_path_key)
@@ -118,6 +137,22 @@ def get_configuration_path(request_environment, pycsw_root,
     * The presence of a `config` parameter in the request's query string;
     * A `PYCSW_CONFIG` environment variable;
     * A `PYCSW_CONFIG WSGI variable.
+    
+    Parameters
+    ----------
+    request_environment: dict
+        A mapping with the request's environment. Typically the WSGI's 
+        environment 
+    pycsw_root: str
+        pycsw's default root path
+    config_path_key: str, optional
+        Name of the variable that specifies the path to pycsw's configuration 
+        file.
+        
+    Returns
+    -------
+    str
+        Path where pycsw expects to find its own configuration file
 
     """
 

--- a/pycsw/wsgi.py
+++ b/pycsw/wsgi.py
@@ -54,6 +54,7 @@
 # http://localhost:8000/
 #
 
+import gzip
 import os
 import sys
 
@@ -114,7 +115,6 @@ def compress_response(response, compression_level):
 
     """
 
-    import gzip
     buf = six.BytesIO()
     gzipfile = gzip.GzipFile(mode='wb', fileobj=buf,
                              compresslevel=compression_level)

--- a/tests/unittests/test_wsgi.py
+++ b/tests/unittests/test_wsgi.py
@@ -37,6 +37,10 @@ pytestmark = pytest.mark.unit
 
 
 def test_get_pycsw_root_path():
+    """Ensure that os.getenv is called and that application environment is 
+    read first before wsgi request environment
+    """
+
     fake_root_path_key = "something"
     fake_env = "stuff"
     fake_request_environment = {

--- a/tests/unittests/test_wsgi.py
+++ b/tests/unittests/test_wsgi.py
@@ -1,0 +1,51 @@
+# =================================================================
+#
+# Authors: Ricardo Garcia Silva <ricardo.garcia.silva@gmail.com>
+#
+# Copyright (c) 2017 Ricardo Garcia Silva
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+"""Unit tests for pycsw.wsgi"""
+
+import mock
+import pytest
+
+from pycsw import wsgi
+
+pytestmark = pytest.mark.unit
+
+
+def test_get_pycsw_root_path():
+    fake_root_path_key = "something"
+    fake_env = "stuff"
+    fake_request_environment = {
+        fake_root_path_key: fake_env,
+    }
+    with mock.patch("pycsw.wsgi.os", autospec=True) as mock_os:
+        mock_os.getenv.return_value = True
+        result = wsgi.get_pycsw_root_path(
+            fake_request_environment,
+            root_path_key=fake_root_path_key
+        )
+        mock_os.getenv.assert_called_with(fake_root_path_key, fake_env)


### PR DESCRIPTION
# Overview

# Related Issue / Discussion

#508 - There is no way to get PYCSW_CONFIG from the os environment when using wsgi servers

# Additional Information

TODO before review:

- [x] - Implement the code changes
- [x] - Add documentation to any new functions
- [x] - Add some unit tests

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
