### PR TITLE
removed python 2.6 from the tox settings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py26,py27,py34,py35}-sqlite
+envlist = {py27,py34,py35}-sqlite
 skip_missing_interpreters = True
 
 
@@ -13,5 +13,5 @@ deps =
     -rrequirements-dev.txt
 usedevelop=True
 commands =
-    py{26,27,35}-sqlite: py.test {posargs}
+    py{27,35}-sqlite: py.test {posargs}
     py34-sqlite: py.test --cov pycsw {posargs}


### PR DESCRIPTION
# Overview

This PR removes python2.6 from the tox settings.

# Related Issue / Discussion

See #513 

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
