### PR TITLE
codecov integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,53 +6,49 @@ dist: trusty
 
 jobs:
   include:
+
     - stage: unit-test
       python: "2.7"
       env: TOXENV=py27-sqlite
-      install: pip install tox
+      install: pip install codecov tox
       script: tox -- --exitfirst -m unit
+      after_success: codecov -F unittests
+
     - stage: unit-test
       python: "3.4"
       env: TOXENV=py34-sqlite
-      install: pip install tox
+      install: pip install codecov tox
       script: tox -- --exitfirst -m unit
+      after_success: codecov -F unittests
+
     - stage: unit-test
       python: "3.5"
       env: TOXENV=py35-sqlite
-      install: pip install tox
-      script: tox -- --exitfirst -m unit
-
-    - stage: unit-coverage-upload
-      python: "2.7"
-      env: TOXENV=coverage-report-sqlite
       install: pip install codecov tox
-      script:
-        - tox
-        - codecov -F unittests
+      script: tox -- --exitfirst -m unit
+      after_success: codecov -F unittests
 
     - stage: integration-test
       python: "2.7"
       env: TOXENV=py27-sqlite
-      install: pip install tox
+      install: pip install codecov tox
       script: tox -- --exitfirst -m functional -k 'not harvesting'
+      after_success: codecov -F integrationtests
+
     - stage: integration-test
       python: "3.4"
       env: TOXENV=py34-sqlite
-      install: pip install tox
+      install: pip install codecov tox
       script: tox -- --exitfirst -m functional -k 'not harvesting'
+      after_success: codecov -F integrationtests
+
     - stage: integration-test
       python: "3.5"
       env: TOXENV=py35-sqlite
-      install: pip install tox
-      script: tox -- --exitfirst -m functional -k 'not harvesting'
-
-    - stage: integration-coverage-upload
-      python: "2.7"
-      env: TOXENV=coverage-report-sqlite
       install: pip install codecov tox
-      script:
-        - tox
-        - codecov -F integrationtests
+      script: tox -- --exitfirst -m functional -k 'not harvesting'
+      after_success: codecov -F integrationtests
+
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,55 @@ cache: pip
 
 dist: trusty
 
-matrix:
+jobs:
   include:
-    - python: "2.7"
+    - stage: unit-test
+      python: "2.7"
       env: TOXENV=py27-sqlite
-    - python: "3.4"
+      install: pip install tox
+      script: tox -- --exitfirst -m unit
+    - stage: unit-test
+      python: "3.4"
       env: TOXENV=py34-sqlite
-    - python: "3.5"
+      install: pip install tox
+      script: tox -- --exitfirst -m unit
+    - stage: unit-test
+      python: "3.5"
       env: TOXENV=py35-sqlite
+      install: pip install tox
+      script: tox -- --exitfirst -m unit
+
+    - stage: unit-coverage-upload
+      python: "2.7"
+      env: TOXENV=coverage-report-sqlite
+      install: pip install codecov tox
+      script:
+        - tox
+        - codecov -F unittests
+
+    - stage: integration-test
+      python: "2.7"
+      env: TOXENV=py27-sqlite
+      install: pip install tox
+      script: tox -- --exitfirst -m functional -k 'not harvesting'
+    - stage: integration-test
+      python: "3.4"
+      env: TOXENV=py34-sqlite
+      install: pip install tox
+      script: tox -- --exitfirst -m functional -k 'not harvesting'
+    - stage: integration-test
+      python: "3.5"
+      env: TOXENV=py35-sqlite
+      install: pip install tox
+      script: tox -- --exitfirst -m functional -k 'not harvesting'
+
+    - stage: integration-coverage-upload
+      python: "2.7"
+      env: TOXENV=coverage-report-sqlite
+      install: pip install codecov tox
+      script:
+        - tox
+        - codecov -F integrationtests
 
 addons:
   apt:
@@ -22,12 +63,6 @@ addons:
       - libxslt1-dev
       - libz-dev
 
-install:
-  - pip install tox
-
-script:
-  - tox -- --exitfirst -m unit
-  - tox -- --exitfirst -m functional -k 'not harvesting'
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,42 +12,42 @@ jobs:
       env: TOXENV=py27-sqlite
       install: pip install codecov tox
       script: tox -- --exitfirst -m unit
-      after_success: codecov -F unittests
+      after_success: codecov --disable search --flags unittests
 
     - stage: unit-test
       python: "3.4"
       env: TOXENV=py34-sqlite
       install: pip install codecov tox
       script: tox -- --exitfirst -m unit
-      after_success: codecov -F unittests
+      after_success: codecov --disable search --flags unittests
 
     - stage: unit-test
       python: "3.5"
       env: TOXENV=py35-sqlite
       install: pip install codecov tox
       script: tox -- --exitfirst -m unit
-      after_success: codecov -F unittests
+      after_success: codecov --disable search --flags unittests
 
     - stage: integration-test
       python: "2.7"
       env: TOXENV=py27-sqlite
       install: pip install codecov tox
       script: tox -- --exitfirst -m functional -k 'not harvesting'
-      after_success: codecov -F integrationtests
+      after_success: codecov --disable search --flags integrationtests
 
     - stage: integration-test
       python: "3.4"
       env: TOXENV=py34-sqlite
       install: pip install codecov tox
       script: tox -- --exitfirst -m functional -k 'not harvesting'
-      after_success: codecov -F integrationtests
+      after_success: codecov --disable search --flags integrationtests
 
     - stage: integration-test
       python: "3.5"
       env: TOXENV=py35-sqlite
       install: pip install codecov tox
       script: tox -- --exitfirst -m functional -k 'not harvesting'
-      after_success: codecov -F integrationtests
+      after_success: codecov --disable search --flags integrationtests
 
 
 addons:

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,19 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py27,py34,py35}-sqlite
+envlist = {py27,py34,py35}-sqlite,coverage-report-sqlite
 skip_missing_interpreters = True
 
 
 [testenv]
 deps =
     -rrequirements-dev.txt
-usedevelop=True
+usedevelop = True
 commands =
-    py{27,35}-sqlite: py.test {posargs}
-    py34-sqlite: py.test --cov pycsw {posargs}
+    coverage run --parallel-mode --module pytest {posargs}
+
+[testenv:coverage-report-sqlite]
+skip_install = True
+commands =
+    coverage combine
+    coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py27,py34,py35}-sqlite,coverage-report-sqlite
+envlist = {py27,py34,py35}-sqlite
 skip_missing_interpreters = True
 
 
@@ -14,9 +14,5 @@ deps =
 usedevelop = True
 commands =
     coverage run --parallel-mode --module pytest {posargs}
-
-[testenv:coverage-report-sqlite]
-skip_install = True
-commands =
-    coverage combine
+    coverage combine --append
     coverage report


### PR DESCRIPTION
# Overview

This PR brings integration with the [codecov](https://codecov.io/) service.

The general idea is that our CI service will run the tests with `coverage.py` and afterwards upload coverage results to codecov. This involves running parallel coverage and then combining everything in the end.
It will be using the [new multi-stage capabilities in Travis](https://docs.travis-ci.com/user/build-stages/) (which are awesome by the way).

# Related Issue / Discussion

See #511 

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
