### PR TITLE
decouple requirements files in lieu of assembling via tox config 

### DIFF
--- a/docs/requirements-mocked.txt
+++ b/docs/requirements-mocked.txt
@@ -1,0 +1,5 @@
+# This file holds some fake requirements to fool the readthedocs service into
+# building the documentation. For more information, see
+# https://github.com/geopython/pycsw/issues/521
+mock
+sphinx


### PR DESCRIPTION
# Overview
Unchains `requirements-dev.txt` file and explicitly specify in `tox.ini` instead.

# Related Issue / Discussion
#521, #497 

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
