### PR TITLE
move get_anytext() function to pycsw.core.util

### DIFF
--- a/pycsw/core/admin.py
+++ b/pycsw/core/admin.py
@@ -217,8 +217,8 @@ def setup_db(database, table, home, create_sfsql_tables=True, create_plpythonu_f
         AS $$
             import sys
             sys.path.append('%s')
-            from pycsw.core import repository
-            return repository.get_anytext(xml)
+            from pycsw.core import util
+            return util.get_anytext(xml)
             $$ LANGUAGE plpythonu;
         ''' % pycsw_home
             function_query_spatial = '''

--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -42,7 +42,6 @@ from shapely.wkt import loads
 from shapely.geometry import MultiPolygon
 
 from pycsw.core.etree import etree
-from pycsw.core import repository
 from pycsw.core import util
 
 LOGGER = logging.getLogger(__name__)
@@ -177,7 +176,7 @@ def _parse_csw(context, repos, record, identifier, pagesize=10):
         context,
         serviceobj,
         'pycsw:AnyText',
-        repository.get_anytext(md._exml)
+        util.get_anytext(md._exml)
     )
     _set(context, serviceobj, 'pycsw:Type', 'service')
     _set(context, serviceobj, 'pycsw:Title', md.identification.title)
@@ -332,7 +331,7 @@ def _parse_wms(context, repos, record, identifier):
         context,
         serviceobj,
         'pycsw:AnyText',
-        repository.get_anytext(md.getServiceXML())
+        util.get_anytext(md.getServiceXML())
     )
     _set(context, serviceobj, 'pycsw:Type', 'service')
     _set(context, serviceobj, 'pycsw:Title', md.identification.title)
@@ -391,7 +390,7 @@ def _parse_wms(context, repos, record, identifier):
             context,
             recobj,
             'pycsw:AnyText',
-            repository.get_anytext([
+            util.get_anytext([
                 md.contents[layer].title,
                 md.contents[layer].abstract,
                 ','.join(md.contents[layer].keywords)
@@ -469,7 +468,7 @@ def _parse_wmts(context, repos, record, identifier):
         context,
         serviceobj,
         'pycsw:AnyText',
-        repository.get_anytext(md.getServiceXML())
+        util.get_anytext(md.getServiceXML())
     )
     _set(context, serviceobj, 'pycsw:Type', 'service')
     _set(context, serviceobj, 'pycsw:Title', md.identification.title)
@@ -538,7 +537,7 @@ def _parse_wmts(context, repos, record, identifier):
             context,
             recobj,
             'pycsw:AnyText',
-             repository.get_anytext([
+             util.get_anytext([
                  md.contents[layer].title,
                  md.contents[layer].abstract,
                  ','.join(keywords)
@@ -605,7 +604,7 @@ def _parse_wfs(context, repos, record, identifier, version):
         context,
         serviceobj,
         'pycsw:AnyText',
-        repository.get_anytext(etree.tostring(md._capabilities))
+        util.get_anytext(etree.tostring(md._capabilities))
     )
     _set(context, serviceobj, 'pycsw:Type', 'service')
     _set(context, serviceobj, 'pycsw:Title', md.identification.title)
@@ -655,7 +654,7 @@ def _parse_wfs(context, repos, record, identifier, version):
             context,
             recobj,
             'pycsw:AnyText',
-            repository.get_anytext([
+            util.get_anytext([
                 md.contents[featuretype].title,
                 md.contents[featuretype].abstract,
                 ','.join(md.contents[featuretype].keywords)
@@ -721,7 +720,7 @@ def _parse_wcs(context, repos, record, identifier):
         context,
         serviceobj,
         'pycsw:AnyText',
-        repository.get_anytext(etree.tostring(md._capabilities))
+        util.get_anytext(etree.tostring(md._capabilities))
     )
     _set(context, serviceobj, 'pycsw:Type', 'service')
     _set(context, serviceobj, 'pycsw:Title', md.identification.title)
@@ -771,7 +770,7 @@ def _parse_wcs(context, repos, record, identifier):
             context,
             recobj,
             'pycsw:AnyText',
-            repository.get_anytext([
+            util.get_anytext([
                 md.contents[coverage].title,
                 md.contents[coverage].abstract,
                 ','.join(md.contents[coverage].keywords)
@@ -827,7 +826,7 @@ def _parse_wps(context, repos, record, identifier):
         context,
         serviceobj,
         'pycsw:AnyText',
-        repository.get_anytext(md._capabilities)
+        util.get_anytext(md._capabilities)
     )
     _set(context, serviceobj, 'pycsw:Type', 'service')
     _set(context, serviceobj, 'pycsw:Title', md.identification.title)
@@ -879,7 +878,7 @@ def _parse_wps(context, repos, record, identifier):
             context,
             recobj,
             'pycsw:AnyText',
-            repository.get_anytext([process.title, process.abstract])
+            util.get_anytext([process.title, process.abstract])
         )
 
         params = {
@@ -925,7 +924,7 @@ def _parse_sos(context, repos, record, identifier, version):
         context,
         serviceobj,
         'pycsw:AnyText',
-        repository.get_anytext(etree.tostring(md._capabilities))
+        util.get_anytext(etree.tostring(md._capabilities))
     )
     _set(context, serviceobj, 'pycsw:Type', 'service')
     _set(context, serviceobj, 'pycsw:Title', md.identification.title)
@@ -991,7 +990,7 @@ def _parse_sos(context, repos, record, identifier, version):
         anytext = []
         anytext.append(md.contents[offering].description)
         anytext.extend(observed_properties)
-        _set(context, recobj, 'pycsw:AnyText', repository.get_anytext(anytext))
+        _set(context, recobj, 'pycsw:AnyText', util.get_anytext(anytext))
         _set(context, recobj, 'pycsw:Keywords', ','.join(observed_properties))
 
         bbox = md.contents[offering].bbox
@@ -1038,7 +1037,7 @@ def _parse_fgdc(context, repos, exml):
     _set(context, recobj, 'pycsw:MdSource', 'local')
     _set(context, recobj, 'pycsw:InsertDate', util.get_today_and_now())
     _set(context, recobj, 'pycsw:XML', md.xml)
-    _set(context, recobj, 'pycsw:AnyText', repository.get_anytext(exml))
+    _set(context, recobj, 'pycsw:AnyText', util.get_anytext(exml))
     _set(context, recobj, 'pycsw:Language', 'en-US')
 
     if hasattr(md.idinfo, 'descript'):
@@ -1134,7 +1133,7 @@ def _parse_gm03(context, repos, exml):
     _set(context, recobj, 'pycsw:MdSource', 'local')
     _set(context, recobj, 'pycsw:InsertDate', util.get_today_and_now())
     _set(context, recobj, 'pycsw:XML', md.xml)
-    _set(context, recobj, 'pycsw:AnyText', repository.get_anytext(exml))
+    _set(context, recobj, 'pycsw:AnyText', util.get_anytext(exml))
     _set(context, recobj, 'pycsw:Language', data.metadata.language)
     _set(context, recobj, 'pycsw:Type', data.metadata.hierarchy_level[0])
     _set(context, recobj, 'pycsw:Date', data.metadata.date_stamp)
@@ -1225,7 +1224,7 @@ def _parse_iso(context, repos, exml):
     _set(context, recobj, 'pycsw:MdSource', 'local')
     _set(context, recobj, 'pycsw:InsertDate', util.get_today_and_now())
     _set(context, recobj, 'pycsw:XML', md.xml)
-    _set(context, recobj, 'pycsw:AnyText', repository.get_anytext(exml))
+    _set(context, recobj, 'pycsw:AnyText', util.get_anytext(exml))
     _set(context, recobj, 'pycsw:Language', md.language)
     _set(context, recobj, 'pycsw:Type', md.hierarchy)
     _set(context, recobj, 'pycsw:ParentIdentifier', md.parentidentifier)
@@ -1416,7 +1415,7 @@ def _parse_dc(context, repos, exml):
     _set(context, recobj, 'pycsw:MdSource', 'local')
     _set(context, recobj, 'pycsw:InsertDate', util.get_today_and_now())
     _set(context, recobj, 'pycsw:XML', md.xml)
-    _set(context, recobj, 'pycsw:AnyText', repository.get_anytext(exml))
+    _set(context, recobj, 'pycsw:AnyText', util.get_anytext(exml))
     _set(context, recobj, 'pycsw:Language', md.language)
     _set(context, recobj, 'pycsw:Type', md.type)
     _set(context, recobj, 'pycsw:Title', md.title)

--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -416,7 +416,7 @@ def create_custom_sql_functions(connection):
     for function_object in [
         query_spatial,
         update_xpath,
-        get_anytext,
+        util.get_anytext,
         get_geometry_area,
         get_spatial_overlay_rank
     ]:
@@ -426,22 +426,6 @@ def create_custom_sql_functions(connection):
             len(argspec.args),
             function_object
         )
-
-
-def get_anytext(bag):
-    """
-    generate bag of text for free text searches
-    accepts list of words, string of XML, or etree.Element
-    """
-
-    if isinstance(bag, list):  # list of words
-        return ' '.join([_f for _f in bag if _f]).strip()
-    else:  # xml
-        if isinstance(bag, six.binary_type) or isinstance(bag, six.text_type):
-            # serialize to lxml
-            bag = etree.fromstring(bag, PARSER)
-        # get all XML element content
-        return ' '.join([value.strip() for value in bag.xpath('//text()')])
 
 
 def query_spatial(bbox_data_wkt, bbox_input_wkt, predicate, distance):

--- a/pycsw/core/util.py
+++ b/pycsw/core/util.py
@@ -36,10 +36,13 @@ import datetime
 import logging
 import time
 
+import six
 from six.moves.urllib.request import Request, urlopen
 from six.moves.urllib.parse import urlparse
 from shapely.wkt import loads
 from owslib.util import http_post
+
+from pycsw.core.etree import etree, PARSER
 
 LOGGER = logging.getLogger(__name__)
 
@@ -307,3 +310,19 @@ def ipaddress_in_whitelist(ipaddress, whitelist):
                     if ipaddress.startswith(white.split('*')[0]):
                         return True
     return False
+
+
+def get_anytext(bag):
+    """
+    generate bag of text for free text searches
+    accepts list of words, string of XML, or etree.Element
+    """
+
+    if isinstance(bag, list):  # list of words
+        return ' '.join([_f for _f in bag if _f]).strip()
+    else:  # xml
+        if isinstance(bag, six.binary_type) or isinstance(bag, six.text_type):
+            # serialize to lxml
+            bag = etree.fromstring(bag, PARSER)
+        # get all XML element content
+        return ' '.join([value.strip() for value in bag.xpath('//text()')])


### PR DESCRIPTION
# Overview
This PR moves `pycsw.core.repository.get_anytext` back to `pycsw.core.util.get_anytext`. `pycsw.core.repository` requires dependency on sqlalchemy which, when integrating pycsw with tools like GeoNode, HHypermap, CKAN, etc., introduces a dependency that is not required.

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
