### PR TITLE
support CSW WKT ENVELOPE syntax (#532)

### DIFF
--- a/pycsw/core/util.py
+++ b/pycsw/core/util.py
@@ -154,6 +154,14 @@ def nspath_eval(xpath, nsmap):
     return '/'.join(out)
 
 
+def wktenvelope2bbox(envelope):
+    """returns bbox string of WKT ENVELOPE definition"""
+
+    tmparr = [x.strip() for x in envelope.split('(')[1].split(')')[0].split(',')]
+    bbox = '%s,%s,%s,%s' % (tmparr[0], tmparr[3], tmparr[1], tmparr[2])
+    return bbox
+
+
 def wkt2geom(ewkt, bounds=True):
     """Return Shapely geometry object based on WKT/EWKT
 
@@ -179,6 +187,8 @@ def wkt2geom(ewkt, bounds=True):
     """
 
     wkt = ewkt.split(";")[-1] if ewkt.find("SRID") != -1 else ewkt
+    if wkt.startswith('ENVELOPE'):
+        wkt = bbox2wktpolygon(wktenvelope2bbox(wkt))
     geometry = loads(wkt)
     return geometry.envelope.bounds if bounds else geometry
 
@@ -198,6 +208,8 @@ def bbox2wktpolygon(bbox):
 
     """
 
+    if bbox.startswith('ENVELOPE'):
+        bbox = wktenvelope2bbox(bbox)
     minx, miny, maxx, maxy = [float(coord) for coord in bbox.split(",")]
     return 'POLYGON((%.2f %.2f, %.2f %.2f, %.2f %.2f, %.2f %.2f, %.2f %.2f))' \
         % (minx, miny, minx, maxy, maxx, maxy, maxx, miny, minx, miny)

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -113,6 +113,14 @@ def test_nspath_eval_invalid_element():
             }
         )
 
+@pytest.mark.parametrize("envelope, expected", [
+    ("ENVELOPE (-180,180,90,-90)", "-180,-90,180,90"),
+    (" ENVELOPE(-180,180,90,-90)", "-180,-90,180,90"),
+    (" ENVELOPE( -180, 180, 90, -90) ", "-180,-90,180,90"),
+])
+def test_wktenvelope2bbox(envelope, expected):
+    result = util.wktenvelope2bbox(envelope)
+    assert result == expected
 
 # TODO - Add more WKT cases for other geometry types
 @pytest.mark.parametrize("wkt, bounds, expected", [


### PR DESCRIPTION
# Overview
Provides mediation from WKT ENVELOPE to/for Shapely parsing.
# Related Issue / Discussion

# Additional Information
#532 
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
