### PR TITLE
made psycopg2 an optional dependency for functional tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
 -r requirements-standalone.txt
--r requirements-pg.txt
 
 mock==2.0.0
 Paver==1.2.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 -r requirements-standalone.txt
 
+apipkg==1.4
 mock==2.0.0
 Paver==1.2.4
 pytest==3.0.3

--- a/tests/functionaltests/conftest.py
+++ b/tests/functionaltests/conftest.py
@@ -35,11 +35,17 @@ import os
 import re
 from six.moves import configparser
 
-import psycopg2
+import apipkg
 import pytest
 
 from pycsw.core import admin
 from pycsw.core.config import StaticContext
+
+apipkg.initpkg("optionaldependencies", {
+    "psycopg2": "psycopg2",
+})
+
+from optionaldependencies import psycopg2  # NOQA: E402
 
 TESTS_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 


### PR DESCRIPTION
# Overview

This PR makes `psycopg2` an optional dependency for devs.

Currently our functional test suites are configured in the `tests/functionaltests/conftest.py` module. This module is always importing `psycopg2` regardless if the tests are using a postgres database or not.

The proposed implementation uses the [apipkg](https://github.com/pytest-dev/apipkg) package. This is a small, pure-python module that enables lazy loading of dependencies. Modules that are lazy loaded with `apipkg` are only loaded when needed. In addition to this change, the `requirements-dev.txt` file no longer includes `requirements-pg.txt`.


# Related Issue / Discussion

#497 

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
