### PR TITLE
safeguard strip whitespace from version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ from setuptools import find_packages, setup
 def read(filename, encoding="utf-8"):
     full_path = os.path.join(os.path.dirname(__file__), filename)
     with io.open(full_path, encoding=encoding) as fh:
-        contents = fh.read()
+        contents = fh.read().strip()
     return contents
 
 


### PR DESCRIPTION
# Overview
Minor safeguard.  Even thought PEP 440 covers whitespaces, safeguarding makes sense for workflows beyond PEP440/PyPI, etc.
# Related Issue / Discussion
#535 
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
