### PR TITLE
Filter query to show only public records

### DIFF
--- a/pycsw/plugins/repository/odc/odc.py
+++ b/pycsw/plugins/repository/odc/odc.py
@@ -34,6 +34,8 @@ from django.db import models
 from django.db import connection
 from django.db.models import Avg, Max, Min, Count
 from django.conf import settings
+from guardian.shortcuts import get_objects_for_user
+from django.contrib.auth.models import AnonymousUser
 
 from pycsw.core import repository, util
 from OpenDataCatalog.opendata.models import Resource
@@ -130,6 +132,10 @@ class OpenDataCatalogRepository(object):
 
         else:  # GetRecords sans constraint
             query = self._get_repo_filter(Resource.objects)
+        
+        # filter query to show only public records
+        permitted = get_objects_for_user(AnonymousUser(), 'base.view_resourcebase')
+        query = query.filter(id__in=permitted)
 
         total = query.count()
 


### PR DESCRIPTION
# Overview
Hides records that are not public (i.e. records that should be hidden from the anonymous user).  However, it also hides records with restricted access that should be accessible to the requesting user. 

Tested on Geonode 2.4 but not Geonode master.

# Related Issue / Discussion

Towards a fix for Geonode issue [#1726](https://github.com/GeoNode/geonode/issues/1726).

Works for anonymous CSW requests, but not authenticated requests.

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute a bugfix to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
