### PR TITLE
Docker documentation update

### DIFF
--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -2,12 +2,26 @@ Docker
 ======
 
 pycsw is available as a Docker image. The image is hosted on the docker hub
-at geopython/pyycsw. It can be obtained by running:
+at [geopython/pycsw](https://hub.docker.com/r/geopython/pycsw/). It can be obtained by running:
 
 docker pull geopython/pycsw:<pycsw-version>
 
 The ``latest`` tag is also availabe and corresponds to the most up to date 
 master branch.
+
+Assuming you already have [docker installed](), you can get a pycsw instance up and running by issuing the following
+command::
+
+    docker run -p 8000:8000 geopython/pycsw
+
+Docker will retrieve the pycsw image from docker hub (if needed) and then start a new container listening on port 8000.
+
+The default configuration will run pycsw with an sqlite repository backend loaded with some test data from the CITE
+test suite. You cna use this to take pycsw for a test drive.
+
+
+Running custom pycsw instances
+------------------------------
 
 pycsw.cfg
 +++++++++
@@ -17,20 +31,19 @@ mount or as a docker secret (in the case of docker swarm). The configuration
 file is searched at the value of the ``PYCSW_CONFIG`` environmental variable,
 which defaults to ``/etc/pycsw/pycsw.cfg``. 
 
-Supplying the configuration file via bind mount:
+Supplying the configuration file via bind mount::
 
-docker run \
-    --name pycsw \
-    --dettach \
-    -v <path-to-pycsw.cfg>:/etc/pycsw/pycsw.cfg \
-    -p 8000:8000 \
-    geopython/pycsw
+    docker run \
+        --name pycsw \
+        --detach \
+        -v <path-to-local-pycsw.cfg>:/etc/pycsw/pycsw.cfg \
+        -p 8000:8000 \
+        geopython/pycsw
 
+Supplying the configuration file via docker secrets::
 
-Supplying the configuration file via docker secrets:
-
-docker secret create pycsw.cfg <path-to-pycsw.cfg>
-docker service create --name pycsw --secret pycsw.cfg geopython/pycsw
+    docker secret create pycsw-config <path-to-local-pycsw.cfg>
+    docker service create --name pycsw --secret pycsw.cfg geopython/pycsw
 
 
 sqlite repositories

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -1,30 +1,58 @@
 Docker
-======
+------
 
-pycsw is available as a Docker image. The image is hosted on the docker hub
-at [geopython/pycsw](https://hub.docker.com/r/geopython/pycsw/). It can be obtained by running:
+pycsw is available as a Docker image. The image is hosted on the `dockerhub`_.
 
-docker pull geopython/pycsw:<pycsw-version>
-
-The ``latest`` tag is also availabe and corresponds to the most up to date 
-master branch.
-
-Assuming you already have [docker installed](), you can get a pycsw instance up and running by issuing the following
-command::
+Assuming you already have docker installed, you can get a pycsw instance up
+and running by issuing the following command::
 
     docker run -p 8000:8000 geopython/pycsw
 
-Docker will retrieve the pycsw image from docker hub (if needed) and then start a new container listening on port 8000.
+Docker will retrieve the pycsw image from dockerhub (if needed) and then
+start a new container listening on port 8000.
 
-The default configuration will run pycsw with an sqlite repository backend loaded with some test data from the CITE
-test suite. You cna use this to take pycsw for a test drive.
+The default configuration will run pycsw with an sqlite repository backend
+loaded with some test data from the CITE test suite. You can use this to take
+pycsw for a test drive.
 
 
-Running custom pycsw instances
-------------------------------
+Inspect logs
+^^^^^^^^^^^^
 
-pycsw.cfg
-+++++++++
+The default configuration for the docker image outputs logs to stdout. This is
+common practice with docker containers and enables the inspection of logs
+with the ``docker logs`` command::
+
+    # run a pycsw container in the background
+    docker run \
+        --name pycsw-test \
+        --publish 8000:8000 \
+        --detach \
+        geopython/pycsw
+
+    # inspect logs
+    docker logs pycsw-test
+
+.. note::
+
+   In order to have pycsw logs being sent to standard output you must set
+   ``server.logfile=`` in the pycsw configuration file.
+
+
+Using pycsw-admin
+^^^^^^^^^^^^^^^^^
+
+``pycsw-admin`` can be executed on a running container by
+using ``docker exec``::
+
+    docker exec -ti <running-container-id> pycsw-admin.py -h
+
+
+Running custom pycsw containers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+pycsw configuration
++++++++++++++++++++
 
 It is possible to supply a custom configuration file for pycsw as a bind 
 mount or as a docker secret (in the case of docker swarm). The configuration 
@@ -36,60 +64,106 @@ Supplying the configuration file via bind mount::
     docker run \
         --name pycsw \
         --detach \
-        -v <path-to-local-pycsw.cfg>:/etc/pycsw/pycsw.cfg \
-        -p 8000:8000 \
+        --volume <path-to-local-pycsw.cfg>:/etc/pycsw/pycsw.cfg \
+        --publish 8000:8000 \
         geopython/pycsw
 
 Supplying the configuration file via docker secrets::
 
+    # first create a docker secret with the pycsw config file
     docker secret create pycsw-config <path-to-local-pycsw.cfg>
-    docker service create --name pycsw --secret pycsw.cfg geopython/pycsw
+    docker service create \
+        --name pycsw \
+        --secret src=pycsw-config,target=/etc/pycsw/pycsw.cfg \
+        --publish 8000:8000
+        geopython/pycsw
 
 
 sqlite repositories
 +++++++++++++++++++
 
 The default database repository is the CITE database that is used for running 
-pycsw's test suites. Docker volumes may be used to specify custom sqlite 
-database path. It should be mounted under ``/var/lib/pycsw``.
+pycsw's test suites. Docker volumes may be used to specify a custom sqlite
+database path. It should be mounted under ``/var/lib/pycsw``::
 
-docker volume create pycsw-db-data
-docker run --volume db-data:/var/lib/pycsw geopython/pycsw
+    # first create a docker volume for persisting the database when
+    # destroying containers
+    docker volume create pycsw-db-data
+    docker run \
+        --volume db-data:/var/lib/pycsw \
+        --detach \
+        --publish 8000:8000
+        geopython/pycsw
 
 
-postgresql repositories
+PostgreSQL repositories
 +++++++++++++++++++++++
 
-Specifying a postgresql repository is just a matter of configuring a custom
+Specifying a PostgreSQL repository is just a matter of configuring a custom
 pycsw.cfg file with the correct specification.
-Using a postgis database from the ``mdillon/postgis`` docker repository:
+
+Check `pycsw's github repository`_ for an example of a docker-compose/stack
+file that spins up a postgis database together with a pycsw instance.
 
 
-Logging
-+++++++
+Setting up a development environment with docker
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In order to send logs to standard output, as is customary with docker 
-containers, the pycsw.cfg file should specify the following:
+Working on pycsw's code using docker enables an isolated environment that
+helps ensuring reproducibility while at the same time keeping your base
+system free from pycsw related dependencies. This can be achieved by:
 
-``core.logfile=-``
+* Cloning pycsw's repository locally;
+* Starting up a docker container with appropriately set up bind mounts. In
+  addition, the pycsw docker image supports a ``reload`` flag that turns on
+  automatic reloading of the gunicorn web server whenever the code changes;
+* Installing the development dependencies by using ``docker exec`` with the
+  root user;
+
+The following instructions set up a fully working development environment::
+
+    # clone pycsw's repo
+    git clone https://github.com/geopython/pycsw.git
+
+    # start a container for development
+    cd pycsw
+    docker run \
+        --name pycsw-dev \
+        --detach \
+        --volume ${PWD}/pycsw:/usr/lib/python3.5/site-packages/pycsw \
+        --volume ${PWD}/docs:/home/pycsw/docs \
+        --volume ${PWD}/VERSION.txt:/home/pycsw/VERSION.txt \
+        --volume ${PWD}/LICENSE.txt:/home/pycsw/LICENSE.txt \
+        --volume ${PWD}/COMMITTERS.txt:/home/pycsw/COMMITTERS.txt \
+        --volume ${PWD}/CONTRIBUTING.rst:/home/pycsw/CONTRIBUTING.rst \
+        --volume ${PWD}/pycsw/plugins:/home/pycsw/pycsw/plugins \
+        --publish 8000:8000 \
+        geopython/pycsw --reload
+
+    # install additional dependencies used in tests and docs
+    docker exec \
+        -ti \
+        --user root \
+        pycsw-dev pip3 install -r requirements-dev.txt
+
+    # run tests (for example unit tests)
+    docker exec -ti pycsw-dev py.test -m unit
+
+    # build docs
+    docker exec -ti pycsw-dev sh -c "cd docs && make html"
+
+.. note::
+
+   Please note that the pycsw image only uses python 3.5 and that it also does
+   not install pycsw in editable mode. As such it is not possible to
+   use ``tox``.
+
+Since the docs directory is bind mounted from your host machine into the
+container, after building the docs you may inspect their content visually, for
+example by running::
+
+    firefox docs/_build/html/index.html
 
 
-Using pycsw in a standalone docker container
---------------------------------------------
-
-
-docker run \
-    --name pycsw \
-    --dettach \
-    --mount <path/to/pycsw/config>:/etc/pycsw/pycsw.cfg \
-    --publish 8000:8000 \
-    geopython/pycsw
-
-sqlite
-
-
-Using pycsw with docker compose
--------------------------------
-
-Using pycsw with docker swarm
------------------------------
+.. _dockerhub: https://hub.docker.com/r/geopython/pycsw/
+.. _pycsw's github repository: https://github.com/geopython/pycsw/tree/master/docker

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -1,5 +1,5 @@
 Docker
-------
+======
 
 pycsw is available as a Docker image. The image is hosted on the `dockerhub`_.
 
@@ -17,7 +17,7 @@ pycsw for a test drive.
 
 
 Inspect logs
-^^^^^^^^^^^^
+------------
 
 The default configuration for the docker image outputs logs to stdout. This is
 common practice with docker containers and enables the inspection of logs
@@ -40,7 +40,7 @@ with the ``docker logs`` command::
 
 
 Using pycsw-admin
-^^^^^^^^^^^^^^^^^
+-----------------
 
 ``pycsw-admin`` can be executed on a running container by
 using ``docker exec``::
@@ -49,10 +49,10 @@ using ``docker exec``::
 
 
 Running custom pycsw containers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------
 
 pycsw configuration
-+++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^
 
 It is possible to supply a custom configuration file for pycsw as a bind 
 mount or as a docker secret (in the case of docker swarm). The configuration 
@@ -80,7 +80,7 @@ Supplying the configuration file via docker secrets::
 
 
 sqlite repositories
-+++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^
 
 The default database repository is the CITE database that is used for running 
 pycsw's test suites. Docker volumes may be used to specify a custom sqlite
@@ -97,7 +97,7 @@ database path. It should be mounted under ``/var/lib/pycsw``::
 
 
 PostgreSQL repositories
-+++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Specifying a PostgreSQL repository is just a matter of configuring a custom
 pycsw.cfg file with the correct specification.
@@ -107,7 +107,7 @@ file that spins up a postgis database together with a pycsw instance.
 
 
 Setting up a development environment with docker
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------------------------
 
 Working on pycsw's code using docker enables an isolated environment that
 helps ensuring reproducibility while at the same time keeping your base

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -1,0 +1,82 @@
+Docker
+======
+
+pycsw is available as a Docker image. The image is hosted on the docker hub
+at geopython/pyycsw. It can be obtained by running:
+
+docker pull geopython/pycsw:<pycsw-version>
+
+The ``latest`` tag is also availabe and corresponds to the most up to date 
+master branch.
+
+pycsw.cfg
++++++++++
+
+It is possible to supply a custom configuration file for pycsw as a bind 
+mount or as a docker secret (in the case of docker swarm). The configuration 
+file is searched at the value of the ``PYCSW_CONFIG`` environmental variable,
+which defaults to ``/etc/pycsw/pycsw.cfg``. 
+
+Supplying the configuration file via bind mount:
+
+docker run \
+    --name pycsw \
+    --dettach \
+    -v <path-to-pycsw.cfg>:/etc/pycsw/pycsw.cfg \
+    -p 8000:8000 \
+    geopython/pycsw
+
+
+Supplying the configuration file via docker secrets:
+
+docker secret create pycsw.cfg <path-to-pycsw.cfg>
+docker service create --name pycsw --secret pycsw.cfg geopython/pycsw
+
+
+sqlite repositories
++++++++++++++++++++
+
+The default database repository is the CITE database that is used for running 
+pycsw's test suites. Docker volumes may be used to specify custom sqlite 
+database path. It should be mounted under ``/var/lib/pycsw``.
+
+docker volume create pycsw-db-data
+docker run --volume db-data:/var/lib/pycsw geopython/pycsw
+
+
+postgresql repositories
++++++++++++++++++++++++
+
+Specifying a postgresql repository is just a matter of configuring a custom
+pycsw.cfg file with the correct specification.
+Using a postgis database from the ``mdillon/postgis`` docker repository:
+
+
+Logging
++++++++
+
+In order to send logs to standard output, as is customary with docker 
+containers, the pycsw.cfg file should specify the following:
+
+``core.logfile=-``
+
+
+Using pycsw in a standalone docker container
+--------------------------------------------
+
+
+docker run \
+    --name pycsw \
+    --dettach \
+    --mount <path/to/pycsw/config>:/etc/pycsw/pycsw.cfg \
+    --publish 8000:8000 \
+    geopython/pycsw
+
+sqlite
+
+
+Using pycsw with docker compose
+-------------------------------
+
+Using pycsw with docker swarm
+-----------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ pycsw |release| Documentation
 
    introduction
    installation
+   docker
    configuration
    administration
    csw-support

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -220,3 +220,5 @@ which will publish pycsw to ``http://localhost:8000/``
 .. _`Web Server Gateway Interface`: http://en.wikipedia.org/wiki/Web_Server_Gateway_Interface
 .. _`WSGIDaemonProcess`: https://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGIDaemonProcess
 .. _`WSGI reference implementation`: http://docs.python.org/library/wsgiref.html
+
+.. include:: docker.rst

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -220,5 +220,3 @@ which will publish pycsw to ``http://localhost:8000/``
 .. _`Web Server Gateway Interface`: http://en.wikipedia.org/wiki/Web_Server_Gateway_Interface
 .. _`WSGIDaemonProcess`: https://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGIDaemonProcess
 .. _`WSGI reference implementation`: http://docs.python.org/library/wsgiref.html
-
-.. include:: docker.rst


### PR DESCRIPTION
# Overview

This PR adds documentation on how to use pycsw's official Docker image, which has recently been merged with #534 

# Related Issue / Discussion

#530  
#534 


# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
