### PR TITLE
Dockerfile improvements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,5 +8,4 @@ pytest==3.0.3
 pytest-cov==2.4.0
 pytest-flake8==0.8.1
 pytest-timeout==1.2.0
-requests==2.10.0
 sphinx


### PR DESCRIPTION
# Overview

This PR improves the existing `Dockerfile` by adding a few missing stuff from the first implementation. Namely:

- Addition of a `--reload` flag that makes the web server automatically reload whenever the code changes. This is only useful for development purposes, as it simplifies the dev workflow;
- Usage of python's `os.execlp` function, which behaves similarly to bash's `exec`. This causes the entrypoint script to be replaced by the web server (in this case gunicorn) in such a way that the same environment and PID is used. This effectively means that gunicorn is now PID1 of the docker container, making it easier to interact with it. It also means that a running pycsw container will now exit cleanly without errors when it is stopped or removed.

# Related Issue / Discussion
#530  
#534

# Additional Information

I have another also PR #547, which is related to this one. It adds documentation on how to use the docker image.

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
