### PR TITLE
Bring back diff output for functional tests

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -241,6 +241,21 @@ There are three main ways to get more output from running tests:
    py.test -v --capture=no --pycsw-loglevel=debug
 
 
+Comparing results with difflib instead of XML c14n
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The functional tests compare results with their expected values by using
+[XML canonicalisation - XML c14n](https://www.w3.org/TR/xml-c14n/).
+Alternatively, you can call py.test with the ``--functional-prefer-diffs``
+flag. This will enable comparison based on python's ``difflib``. Comparison
+is made on a line-by-line basis and in case of failure, a unified diff will
+be printed to standard output.
+
+.. code:: bash
+
+   py.test -m functional -k 'harvesting' --functional-prefer-diffs
+
+
 Test coverage
 ^^^^^^^^^^^^^
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,13 @@ def pytest_addoption(parser):
         default="warning",
         help="Log level for the pycsw server."
     )
+    parser.addoption(
+        "--functional-prefer-diffs",
+        action="store_true",
+        help="When running functional tests, compare results with their "
+             "expected values by using diffs instead of XML canonicalisation "
+             "(the default)."
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/functionaltests/conftest.py
+++ b/tests/functionaltests/conftest.py
@@ -122,13 +122,16 @@ def pytest_generate_tests(metafunc):
             normalize_ids = True if suite in ("harvesting",
                                               "manager") else False
             suite_dirs = _get_suite_dirs(suite)
+            use_xml_canonicalisation = not metafunc.config.getoption(
+                "--functional-prefer-diffs")
             if suite_dirs.post_tests_dir is not None:
                 post_argvalues, post_ids = _get_post_parameters(
                     post_tests_dir=suite_dirs.post_tests_dir,
                     expected_tests_dir=suite_dirs.expected_results_dir,
                     config_path=config_path,
                     suite_name=suite,
-                    normalize_ids=normalize_ids
+                    normalize_ids=normalize_ids,
+                    use_xml_canonicalisation=use_xml_canonicalisation
                 )
                 arg_values.extend(post_argvalues)
                 test_ids.extend(post_ids)
@@ -138,13 +141,15 @@ def pytest_generate_tests(metafunc):
                     expected_tests_dir=suite_dirs.expected_results_dir,
                     config_path=config_path,
                     suite_name=suite,
-                    normalize_ids=normalize_ids
+                    normalize_ids=normalize_ids,
+                    use_xml_canonicalisation=use_xml_canonicalisation
                 )
                 arg_values.extend(get_argvalues)
                 test_ids.extend(get_ids)
         metafunc.parametrize(
             argnames=["configuration", "request_method", "request_data",
-                      "expected_result", "normalize_identifier_fields"],
+                      "expected_result", "normalize_identifier_fields",
+                      "use_xml_canonicalisation"],
             argvalues=arg_values,
             indirect=["configuration"],
             ids=test_ids,
@@ -229,7 +234,7 @@ def _get_cite_suite_data_dir():
 
 
 def _get_get_parameters(get_tests_dir, expected_tests_dir, config_path,
-                        suite_name, normalize_ids):
+                        suite_name, normalize_ids, use_xml_canonicalisation):
     """Return the parameters suitable for parametrizing HTTP GET tests."""
     method = "GET"
     test_argvalues = []
@@ -246,7 +251,7 @@ def _get_get_parameters(get_tests_dir, expected_tests_dir, config_path,
             )
             test_argvalues.append(
                 (config_path, method, test_params, expected_result_path,
-                 normalize_ids)
+                 normalize_ids, use_xml_canonicalisation)
             )
             test_ids.append(
                 "{suite}_{http_method}_{name}".format(
@@ -257,7 +262,7 @@ def _get_get_parameters(get_tests_dir, expected_tests_dir, config_path,
 
 
 def _get_post_parameters(post_tests_dir, expected_tests_dir, config_path,
-                         suite_name, normalize_ids):
+                         suite_name, normalize_ids, use_xml_canonicalisation):
     """Return the parameters suitable for parametrizing HTTP POST tests."""
     method = "POST"
     test_argvalues = []
@@ -277,7 +282,8 @@ def _get_post_parameters(post_tests_dir, expected_tests_dir, config_path,
         )
         test_argvalues.append(
             (config_path, method, request_path,
-             expected_result_path, normalize_ids)
+             expected_result_path, normalize_ids,
+             use_xml_canonicalisation)
         )
         test_ids.append(
             "{suite}_{http_method}_{file_name}".format(

--- a/tests/functionaltests/test_suites_functional.py
+++ b/tests/functionaltests/test_suites_functional.py
@@ -32,6 +32,7 @@
 
 import codecs
 from difflib import SequenceMatcher
+from difflib import unified_diff
 from io import BytesIO
 import json
 import re
@@ -47,7 +48,7 @@ pytestmark = pytest.mark.functional
 
 
 def test_suites(configuration, request_method, request_data, expected_result,
-                normalize_identifier_fields):
+                normalize_identifier_fields, use_xml_canonicalisation):
     """Test suites.
 
     This function is automatically parametrized by pytest as a result of the
@@ -69,6 +70,9 @@ def test_suites(configuration, request_method, request_data, expected_result,
     normalize_identifier_fields: bool
         Whether to normalize the identifier fields in responses. This
         parameter is used only in the 'harvesting' and 'manager' suites
+    use_xml_canonicalisation: bool
+        Whether to compare results with their expected values by using xml
+        canonicalisation or simply by doing a diff.
 
     """
 
@@ -84,21 +88,37 @@ def test_suites(configuration, request_method, request_data, expected_result,
         contents,
         normalize_identifiers=normalize_identifier_fields
     )
-    try:
-        matches_expected = _test_xml_result(normalized_result, expected)
-    except etree.XMLSyntaxError:
-        # the file is either not XML (perhaps JSON?) or malformed
-        matches_expected = _test_json_result(normalized_result, expected)
-    except etree.C14NError:
-        print("XML canonicalization has failed. Trying to compare result "
-              "with expected using difflib")
-        matches_expected = _test_xml_diff(normalized_result, expected)
+    if use_xml_canonicalisation:
+        print("Comparing results using XML canonicalization...")
+        matches_expected = _compare_with_xml_canonicalisation(
+            normalized_result, expected)
+    else:
+        print("Comparing results using diffs...")
+        matches_expected = _compare_without_xml_canonicalisation(
+            normalized_result, expected)
     if not matches_expected:
         #print("expected: {0}".format(expected.encode(encoding)))
         #print("response: {0}".format(normalized_result.encode(encoding)))
         print("expected: {0}".format(expected))
         print("response: {0}".format(normalized_result))
     assert matches_expected
+
+
+def _compare_with_xml_canonicalisation(normalized_result, expected):
+    try:
+        matches_expected = _test_xml_result(normalized_result, expected)
+    except etree.XMLSyntaxError:
+        # the file is either not XML (perhaps JSON?) or malformed
+        matches_expected = _test_json_result(normalized_result, expected)
+    except etree.C14NError:
+        print("XML canonicalisation has failed. Trying to compare result "
+              "with expected using difflib")
+        matches_expected = _test_xml_diff(normalized_result, expected)
+    return matches_expected
+
+
+def _compare_without_xml_canonicalisation(normalized_result, expected):
+    return _test_xml_diff(normalized_result, expected)
 
 
 def _prepare_wsgi_test_environment(request_method, request_data):
@@ -214,7 +234,7 @@ def _test_json_result(result, expected, encoding="utf-8"):
 def _test_xml_diff(result, expected):
     """Compare two XML strings by using python's ``difflib.SequenceMatcher``.
 
-    This is a character-by-cahracter comparison and does not take into account
+    This is a character-by-character comparison and does not take into account
     the semantic meaning of XML elements and attributes.
 
     Parameters
@@ -233,7 +253,12 @@ def _test_xml_diff(result, expected):
 
     sequence_matcher = SequenceMatcher(None, result, expected)
     ratio = sequence_matcher.ratio()
-    return ratio == pytest.approx(1.0)
+    matches = ratio == pytest.approx(1.0)
+    if not matches:
+        print("Result does not match expected.")
+        diff = unified_diff(result.splitlines(), expected.splitlines())
+        print("\n".join(list(diff)))
+    return matches
 
 
 def _normalize(sresult, normalize_identifiers=False):


### PR DESCRIPTION
# Overview

This PR adds a new `--functional-prefer-diffs` flag to the test runner. It enables comparison of test results with their expected values by using python's `difflib`.

# Related Issue / Discussion

- [latest dev meeting - Action A3](https://github.com/geopython/pycsw/wiki/Meetings-2017-10-16)
- #549 

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
