### PR TITLE
fix CSW  service / version support (optional in 3.0.0) (#544)

### DIFF
--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -282,8 +282,10 @@ class Csw(object):
             if version_202 or accept_version_202:
                 self.request_version = '2.0.2'
         elif self.requesttype == 'POST':
-            if self.request.find(b'2.0.2') != -1:
+            if self.request.find(b'cat/csw/2.0.2') != -1:
                 self.request_version = '2.0.2'
+            elif self.request.find(b'cat/csw/3.0') != -1:
+                self.request_version = '3.0.0'
 
         if (not isinstance(self.kvp, str) and 'mode' in self.kvp and
                 self.kvp['mode'] == 'sru'):
@@ -457,6 +459,12 @@ class Csw(object):
             own_version_integer = util.get_version_integer(
                 self.request_version)
             if self.request_version == '2.0.2':
+                basic_options.append('version')
+            if self.request_version == '3.0.0' and 'version' not in self.kvp:
+                if 'service' not in self.kvp:
+                    self.kvp['service'] = 'CSW'
+                    basic_options.append('service')
+                self.kvp['version'] = self.request_version
                 basic_options.append('version')
 
             for k in basic_options:

--- a/tests/functionaltests/suites/cite/expected/get_c4ea754f-c158-4d8d-8253-dc8f86021b52.xml
+++ b/tests/functionaltests/suites/cite/expected/get_c4ea754f-c158-4d8d-8253-dc8f86021b52.xml
@@ -1,7 +1,545 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<ows20:ExceptionReport xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:ows20="http://www.opengis.net/ows/2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/2.0 http://schemas.opengis.net/ows/2.0/owsExceptionReport.xsd">
-  <ows20:Exception exceptionCode="MissingParameterValue" locator="service">
-    <ows20:ExceptionText>Missing keyword: service</ows20:ExceptionText>
-  </ows20:Exception>
-</ows20:ExceptionReport>
+<csw30:Capabilities xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:csw30="http://www.opengis.net/cat/csw/3.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:fes20="http://www.opengis.net/fes/2.0" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:ows11="http://www.opengis.net/ows/1.1" xmlns:ows20="http://www.opengis.net/ows/2.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updateSequence="PYCSW_UPDATESEQUENCE" version="3.0.0" xsi:schemaLocation="http://www.opengis.net/cat/csw/3.0 http://schemas.opengis.net/csw/3.0/cswGetCapabilities.xsd">
+  <ows20:ServiceIdentification>
+    <ows20:Title>pycsw Geospatial Catalogue</ows20:Title>
+    <ows20:Abstract>pycsw is an OGC CSW server implementation written in Python</ows20:Abstract>
+    <ows20:Keywords>
+      <ows20:Keyword>catalogue</ows20:Keyword>
+      <ows20:Keyword>discovery</ows20:Keyword>
+      <ows20:Type codeSpace="ISOTC211/19115">theme</ows20:Type>
+    </ows20:Keywords>
+    <ows20:ServiceType codeSpace="OGC">CSW</ows20:ServiceType>
+    <ows20:ServiceTypeVersion>2.0.2</ows20:ServiceTypeVersion>
+    <ows20:ServiceTypeVersion>3.0.0</ows20:ServiceTypeVersion>
+    <ows20:Fees>None</ows20:Fees>
+    <ows20:AccessConstraints>None</ows20:AccessConstraints>
+  </ows20:ServiceIdentification>
+  <ows20:ServiceProvider>
+    <ows20:ProviderName>pycsw</ows20:ProviderName>
+    <ows20:ProviderSite xlink:type="simple" xlink:href="http://pycsw.org/"/>
+    <ows20:ServiceContact>
+      <ows20:IndividualName>Kralidis, Tom</ows20:IndividualName>
+      <ows20:PositionName>Senior Systems Scientist</ows20:PositionName>
+      <ows20:ContactInfo>
+        <ows20:Phone>
+          <ows20:Voice>+01-416-xxx-xxxx</ows20:Voice>
+          <ows20:Facsimile>+01-416-xxx-xxxx</ows20:Facsimile>
+        </ows20:Phone>
+        <ows20:Address>
+          <ows20:DeliveryPoint>TBA</ows20:DeliveryPoint>
+          <ows20:City>Toronto</ows20:City>
+          <ows20:AdministrativeArea>Ontario</ows20:AdministrativeArea>
+          <ows20:PostalCode>M9C 3Z9</ows20:PostalCode>
+          <ows20:Country>Canada</ows20:Country>
+          <ows20:ElectronicMailAddress>tomkralidis@gmail.com</ows20:ElectronicMailAddress>
+        </ows20:Address>
+        <ows20:OnlineResource xlink:type="simple" xlink:href="http://kralidis.ca/"/>
+        <ows20:HoursOfService>0800h - 1600h EST</ows20:HoursOfService>
+        <ows20:ContactInstructions>During hours of service.  Off on weekends.</ows20:ContactInstructions>
+      </ows20:ContactInfo>
+      <ows20:Role codeSpace="ISOTC211/19115">pointOfContact</ows20:Role>
+    </ows20:ServiceContact>
+  </ows20:ServiceProvider>
+  <ows20:OperationsMetadata>
+    <ows20:Operation name="GetCapabilities">
+      <ows20:DCP>
+        <ows20:HTTP>
+          <ows20:Get xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/cite/default.cfg"/>
+          <ows20:Post xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/cite/default.cfg"/>
+        </ows20:HTTP>
+      </ows20:DCP>
+      <ows20:Parameter name="acceptFormats">
+        <ows20:AllowedValues>
+          <ows20:Value>application/xml</ows20:Value>
+          <ows20:Value>text/xml</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="acceptVersions">
+        <ows20:AllowedValues>
+          <ows20:Value>2.0.2</ows20:Value>
+          <ows20:Value>3.0.0</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="sections">
+        <ows20:AllowedValues>
+          <ows20:Value>All</ows20:Value>
+          <ows20:Value>Filter_Capabilities</ows20:Value>
+          <ows20:Value>OperationsMetadata</ows20:Value>
+          <ows20:Value>ServiceIdentification</ows20:Value>
+          <ows20:Value>ServiceProvider</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+    </ows20:Operation>
+    <ows20:Operation name="GetDomain">
+      <ows20:DCP>
+        <ows20:HTTP>
+          <ows20:Get xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/cite/default.cfg"/>
+          <ows20:Post xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/cite/default.cfg"/>
+        </ows20:HTTP>
+      </ows20:DCP>
+      <ows20:Parameter name="ParameterName">
+        <ows20:AllowedValues>
+          <ows20:Value>GetCapabilities.acceptFormats</ows20:Value>
+          <ows20:Value>GetCapabilities.acceptVersions</ows20:Value>
+          <ows20:Value>GetCapabilities.sections</ows20:Value>
+          <ows20:Value>GetRecordById.ElementSetName</ows20:Value>
+          <ows20:Value>GetRecordById.outputFormat</ows20:Value>
+          <ows20:Value>GetRecordById.outputSchema</ows20:Value>
+          <ows20:Value>GetRecords.CONSTRAINTLANGUAGE</ows20:Value>
+          <ows20:Value>GetRecords.ElementSetName</ows20:Value>
+          <ows20:Value>GetRecords.outputFormat</ows20:Value>
+          <ows20:Value>GetRecords.outputSchema</ows20:Value>
+          <ows20:Value>GetRecords.typeNames</ows20:Value>
+          <ows20:Value>Harvest.ResourceType</ows20:Value>
+          <ows20:Value>Transaction.TransactionSchemas</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+    </ows20:Operation>
+    <ows20:Operation name="GetRecords">
+      <ows20:DCP>
+        <ows20:HTTP>
+          <ows20:Get xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/cite/default.cfg"/>
+          <ows20:Post xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/cite/default.cfg"/>
+        </ows20:HTTP>
+      </ows20:DCP>
+      <ows20:Parameter name="CONSTRAINTLANGUAGE">
+        <ows20:AllowedValues>
+          <ows20:Value>CQL_TEXT</ows20:Value>
+          <ows20:Value>FILTER</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="ElementSetName">
+        <ows20:AllowedValues>
+          <ows20:Value>brief</ows20:Value>
+          <ows20:Value>full</ows20:Value>
+          <ows20:Value>summary</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="outputFormat">
+        <ows20:AllowedValues>
+          <ows20:Value>application/atom+xml</ows20:Value>
+          <ows20:Value>application/json</ows20:Value>
+          <ows20:Value>application/xml</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="outputSchema">
+        <ows20:AllowedValues>
+          <ows20:Value>http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/</ows20:Value>
+          <ows20:Value>http://www.interlis.ch/INTERLIS2.3</ows20:Value>
+          <ows20:Value>http://www.opengis.net/cat/csw/3.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/cat/csw/csdgm</ows20:Value>
+          <ows20:Value>http://www.w3.org/2005/Atom</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="typeNames">
+        <ows20:AllowedValues>
+          <ows20:Value>csw:Record</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Constraint name="MaxRecordDefault">
+        <ows20:AllowedValues>
+          <ows20:Value>10</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Constraint>
+      <ows20:Constraint name="OpenSearchDescriptionDocument">
+        <ows20:AllowedValues>
+          <ows20:Value>http://localhost/pycsw/csw.py?config=tests/suites/cite/default.cfg?mode=opensearch&amp;service=CSW&amp;version=3.0.0&amp;request=GetCapabilities</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Constraint>
+      <ows20:Constraint name="FederatedCatalogues">
+        <ows20:AllowedValues>
+          <ows20:Value>http://geo.data.gov/geoportal/csw/discovery</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Constraint>
+    </ows20:Operation>
+    <ows20:Operation name="GetRecordById">
+      <ows20:DCP>
+        <ows20:HTTP>
+          <ows20:Get xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/cite/default.cfg"/>
+          <ows20:Post xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/cite/default.cfg"/>
+        </ows20:HTTP>
+      </ows20:DCP>
+      <ows20:Parameter name="ElementSetName">
+        <ows20:AllowedValues>
+          <ows20:Value>brief</ows20:Value>
+          <ows20:Value>full</ows20:Value>
+          <ows20:Value>summary</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="outputFormat">
+        <ows20:AllowedValues>
+          <ows20:Value>application/atom+xml</ows20:Value>
+          <ows20:Value>application/json</ows20:Value>
+          <ows20:Value>application/xml</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="outputSchema">
+        <ows20:AllowedValues>
+          <ows20:Value>http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/</ows20:Value>
+          <ows20:Value>http://www.interlis.ch/INTERLIS2.3</ows20:Value>
+          <ows20:Value>http://www.opengis.net/cat/csw/3.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/cat/csw/csdgm</ows20:Value>
+          <ows20:Value>http://www.w3.org/2005/Atom</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+    </ows20:Operation>
+    <ows20:Operation name="GetRepositoryItem">
+      <ows20:DCP>
+        <ows20:HTTP>
+          <ows20:Get xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/cite/default.cfg"/>
+        </ows20:HTTP>
+      </ows20:DCP>
+    </ows20:Operation>
+    <ows20:Operation name="Transaction">
+      <ows20:DCP>
+        <ows20:HTTP>
+          <ows20:Post xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/cite/default.cfg"/>
+        </ows20:HTTP>
+      </ows20:DCP>
+      <ows20:Parameter name="TransactionSchemas">
+        <ows20:AllowedValues>
+          <ows20:Value>http://www.isotc211.org/2005/gmi</ows20:Value>
+          <ows20:Value>http://www.opengis.net/cat/csw/2.0.2</ows20:Value>
+          <ows20:Value>http://www.opengis.net/cat/csw/3.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/sos/1.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/sos/2.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/wcs</ows20:Value>
+          <ows20:Value>http://www.opengis.net/wfs</ows20:Value>
+          <ows20:Value>http://www.opengis.net/wfs/2.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/wms</ows20:Value>
+          <ows20:Value>http://www.opengis.net/wmts/1.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/wps/1.0.0</ows20:Value>
+          <ows20:Value>urn:geoss:waf</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+    </ows20:Operation>
+    <ows20:Operation name="Harvest">
+      <ows20:DCP>
+        <ows20:HTTP>
+          <ows20:Post xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/cite/default.cfg"/>
+        </ows20:HTTP>
+      </ows20:DCP>
+      <ows20:Parameter name="ResourceType">
+        <ows20:AllowedValues>
+          <ows20:Value>http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/</ows20:Value>
+          <ows20:Value>http://www.interlis.ch/INTERLIS2.3</ows20:Value>
+          <ows20:Value>http://www.isotc211.org/2005/gmi</ows20:Value>
+          <ows20:Value>http://www.opengis.net/cat/csw/2.0.2</ows20:Value>
+          <ows20:Value>http://www.opengis.net/cat/csw/3.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/cat/csw/csdgm</ows20:Value>
+          <ows20:Value>http://www.opengis.net/sos/1.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/sos/2.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/wcs</ows20:Value>
+          <ows20:Value>http://www.opengis.net/wfs</ows20:Value>
+          <ows20:Value>http://www.opengis.net/wfs/2.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/wms</ows20:Value>
+          <ows20:Value>http://www.opengis.net/wmts/1.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/wps/1.0.0</ows20:Value>
+          <ows20:Value>http://www.w3.org/2005/Atom</ows20:Value>
+          <ows20:Value>urn:geoss:waf</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+    </ows20:Operation>
+    <ows20:Parameter name="service">
+      <ows20:AllowedValues>
+        <ows20:Value>CSW</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Parameter>
+    <ows20:Parameter name="version">
+      <ows20:AllowedValues>
+        <ows20:Value>2.0.2</ows20:Value>
+        <ows20:Value>3.0.0</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Parameter>
+    <ows20:Constraint name="CoreQueryables">
+      <ows20:AllowedValues>
+        <ows20:Value>csw:AnyText</ows20:Value>
+        <ows20:Value>dc:contributor</ows20:Value>
+        <ows20:Value>dc:creator</ows20:Value>
+        <ows20:Value>dc:date</ows20:Value>
+        <ows20:Value>dc:format</ows20:Value>
+        <ows20:Value>dc:identifier</ows20:Value>
+        <ows20:Value>dc:language</ows20:Value>
+        <ows20:Value>dc:publisher</ows20:Value>
+        <ows20:Value>dc:relation</ows20:Value>
+        <ows20:Value>dc:rights</ows20:Value>
+        <ows20:Value>dc:source</ows20:Value>
+        <ows20:Value>dc:subject</ows20:Value>
+        <ows20:Value>dc:title</ows20:Value>
+        <ows20:Value>dc:type</ows20:Value>
+        <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
+        <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
+        <ows20:Value>ows:BoundingBox</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="FederatedCatalogues">
+      <ows20:AllowedValues>
+        <ows20:Value>http://geo.data.gov/geoportal/csw/discovery</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="MaxRecordDefault">
+      <ows20:AllowedValues>
+        <ows20:Value>10</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="PostEncoding">
+      <ows20:AllowedValues>
+        <ows20:Value>SOAP</ows20:Value>
+        <ows20:Value>XML</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="XPathQueryables">
+      <ows20:AllowedValues>
+        <ows20:Value>allowed</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/CoreQueryables">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/CoreSortables">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/DefaultSortingAlgorithm">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Filter-CQL">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Filter-FES-KVP-Advanced">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Filter-FES-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetCapabilities-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetDomain-KVP">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetDomain-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetRecordById-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetRecords-Async-KVP">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetRecords-Async-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetRecords-Basic-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetRecords-Distributed-KVP">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetRecords-Distributed-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Harvest-Async-KVP">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Harvest-Async-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Harvest-Basic-KVP">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Harvest-Basic-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Harvest-Periodic-KVP">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Harvest-Periodic-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/OpenSearch">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/SupportedGMLVersions">
+      <ows20:AllowedValues>
+        <ows20:Value>http://www.opengis.net/gml</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Transaction">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+  </ows20:OperationsMetadata>
+  <ows20:Languages>
+    <ows20:Language>en</ows20:Language>
+  </ows20:Languages>
+  <fes20:Filter_Capabilities>
+    <fes20:Conformance>
+      <fes20:Constraint name="ImplementsQuery">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsAdHocQuery">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsFunctions">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsResourceld">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsMinStandardFilter">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsStandardFilter">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsMinSpatialFilter">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsSpatialFilter">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsMinTemporalFilter">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsTemporalFilter">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsVersionNav">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsSorting">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsExtendedOperators">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsMinimumXPath">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsSchemaElementFunc">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+    </fes20:Conformance>
+    <fes20:Id_Capabilities>
+      <fes20:ResourceIdentifier name="csw30:id"/>
+    </fes20:Id_Capabilities>
+    <fes20:Scalar_Capabilities>
+      <fes20:LogicalOperators/>
+      <fes20:ComparisonOperators>
+        <fes20:ComparisonOperator name="PropertyIsBetween"/>
+        <fes20:ComparisonOperator name="PropertyIsEqualTo"/>
+        <fes20:ComparisonOperator name="PropertyIsGreaterThan"/>
+        <fes20:ComparisonOperator name="PropertyIsGreaterThanOrEqualTo"/>
+        <fes20:ComparisonOperator name="PropertyIsLessThan"/>
+        <fes20:ComparisonOperator name="PropertyIsLessThanOrEqualTo"/>
+        <fes20:ComparisonOperator name="PropertyIsLike"/>
+        <fes20:ComparisonOperator name="PropertyIsNotEqualTo"/>
+        <fes20:ComparisonOperator name="PropertyIsNull"/>
+      </fes20:ComparisonOperators>
+    </fes20:Scalar_Capabilities>
+    <fes20:Spatial_Capabilities>
+      <fes20:GeometryOperands>
+        <fes20:GeometryOperand name="gml:Point"/>
+        <fes20:GeometryOperand name="gml:LineString"/>
+        <fes20:GeometryOperand name="gml:Polygon"/>
+        <fes20:GeometryOperand name="gml:Envelope"/>
+      </fes20:GeometryOperands>
+      <fes20:SpatialOperators>
+        <fes20:SpatialOperator name="BBOX"/>
+        <fes20:SpatialOperator name="Beyond"/>
+        <fes20:SpatialOperator name="Contains"/>
+        <fes20:SpatialOperator name="Crosses"/>
+        <fes20:SpatialOperator name="Disjoint"/>
+        <fes20:SpatialOperator name="DWithin"/>
+        <fes20:SpatialOperator name="Equals"/>
+        <fes20:SpatialOperator name="Intersects"/>
+        <fes20:SpatialOperator name="Overlaps"/>
+        <fes20:SpatialOperator name="Touches"/>
+        <fes20:SpatialOperator name="Within"/>
+      </fes20:SpatialOperators>
+    </fes20:Spatial_Capabilities>
+    <fes20:Functions>
+      <fes20:Function name="length">
+        <fes20:Returns>xs:string</fes20:Returns>
+      </fes20:Function>
+      <fes20:Function name="lower">
+        <fes20:Returns>xs:string</fes20:Returns>
+      </fes20:Function>
+      <fes20:Function name="ltrim">
+        <fes20:Returns>xs:string</fes20:Returns>
+      </fes20:Function>
+      <fes20:Function name="rtrim">
+        <fes20:Returns>xs:string</fes20:Returns>
+      </fes20:Function>
+      <fes20:Function name="trim">
+        <fes20:Returns>xs:string</fes20:Returns>
+      </fes20:Function>
+      <fes20:Function name="upper">
+        <fes20:Returns>xs:string</fes20:Returns>
+      </fes20:Function>
+    </fes20:Functions>
+  </fes20:Filter_Capabilities>
+</csw30:Capabilities>

--- a/tests/functionaltests/suites/csw30/expected/get_1869e495-1a61-4713-8285-76d1336ee1a6.xml
+++ b/tests/functionaltests/suites/csw30/expected/get_1869e495-1a61-4713-8285-76d1336ee1a6.xml
@@ -1,7 +1,493 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- PYCSW_VERSION -->
-<ows20:ExceptionReport xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:ows20="http://www.opengis.net/ows/2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/2.0 http://schemas.opengis.net/ows/2.0/owsExceptionReport.xsd">
-  <ows20:Exception exceptionCode="MissingParameterValue" locator="service">
-    <ows20:ExceptionText>Missing keyword: service</ows20:ExceptionText>
-  </ows20:Exception>
-</ows20:ExceptionReport>
+<csw30:Capabilities xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:csw30="http://www.opengis.net/cat/csw/3.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:fes20="http://www.opengis.net/fes/2.0" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:ows11="http://www.opengis.net/ows/1.1" xmlns:ows20="http://www.opengis.net/ows/2.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updateSequence="PYCSW_UPDATESEQUENCE" version="3.0.0" xsi:schemaLocation="http://www.opengis.net/cat/csw/3.0 http://schemas.opengis.net/csw/3.0/cswGetCapabilities.xsd">
+  <ows20:ServiceIdentification>
+    <ows20:Title>pycsw Geospatial Catalogue</ows20:Title>
+    <ows20:Abstract>pycsw is an OGC CSW server implementation written in Python</ows20:Abstract>
+    <ows20:Keywords>
+      <ows20:Keyword>catalogue</ows20:Keyword>
+      <ows20:Keyword>discovery</ows20:Keyword>
+      <ows20:Type codeSpace="ISOTC211/19115">theme</ows20:Type>
+    </ows20:Keywords>
+    <ows20:ServiceType codeSpace="OGC">CSW</ows20:ServiceType>
+    <ows20:ServiceTypeVersion>2.0.2</ows20:ServiceTypeVersion>
+    <ows20:ServiceTypeVersion>3.0.0</ows20:ServiceTypeVersion>
+    <ows20:Fees>None</ows20:Fees>
+    <ows20:AccessConstraints>None</ows20:AccessConstraints>
+  </ows20:ServiceIdentification>
+  <ows20:ServiceProvider>
+    <ows20:ProviderName>pycsw</ows20:ProviderName>
+    <ows20:ProviderSite xlink:type="simple" xlink:href="http://pycsw.org/"/>
+    <ows20:ServiceContact>
+      <ows20:IndividualName>Kralidis, Tom</ows20:IndividualName>
+      <ows20:PositionName>Senior Systems Scientist</ows20:PositionName>
+      <ows20:ContactInfo>
+        <ows20:Phone>
+          <ows20:Voice>+01-416-xxx-xxxx</ows20:Voice>
+          <ows20:Facsimile>+01-416-xxx-xxxx</ows20:Facsimile>
+        </ows20:Phone>
+        <ows20:Address>
+          <ows20:DeliveryPoint>TBA</ows20:DeliveryPoint>
+          <ows20:City>Toronto</ows20:City>
+          <ows20:AdministrativeArea>Ontario</ows20:AdministrativeArea>
+          <ows20:PostalCode>M9C 3Z9</ows20:PostalCode>
+          <ows20:Country>Canada</ows20:Country>
+          <ows20:ElectronicMailAddress>tomkralidis@gmail.com</ows20:ElectronicMailAddress>
+        </ows20:Address>
+        <ows20:OnlineResource xlink:type="simple" xlink:href="http://kralidis.ca/"/>
+        <ows20:HoursOfService>0800h - 1600h EST</ows20:HoursOfService>
+        <ows20:ContactInstructions>During hours of service.  Off on weekends.</ows20:ContactInstructions>
+      </ows20:ContactInfo>
+      <ows20:Role codeSpace="ISOTC211/19115">pointOfContact</ows20:Role>
+    </ows20:ServiceContact>
+  </ows20:ServiceProvider>
+  <ows20:OperationsMetadata>
+    <ows20:Operation name="GetCapabilities">
+      <ows20:DCP>
+        <ows20:HTTP>
+          <ows20:Get xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg"/>
+          <ows20:Post xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg"/>
+        </ows20:HTTP>
+      </ows20:DCP>
+      <ows20:Parameter name="acceptFormats">
+        <ows20:AllowedValues>
+          <ows20:Value>application/xml</ows20:Value>
+          <ows20:Value>text/xml</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="acceptVersions">
+        <ows20:AllowedValues>
+          <ows20:Value>2.0.2</ows20:Value>
+          <ows20:Value>3.0.0</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="sections">
+        <ows20:AllowedValues>
+          <ows20:Value>All</ows20:Value>
+          <ows20:Value>Filter_Capabilities</ows20:Value>
+          <ows20:Value>OperationsMetadata</ows20:Value>
+          <ows20:Value>ServiceIdentification</ows20:Value>
+          <ows20:Value>ServiceProvider</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+    </ows20:Operation>
+    <ows20:Operation name="GetDomain">
+      <ows20:DCP>
+        <ows20:HTTP>
+          <ows20:Get xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg"/>
+          <ows20:Post xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg"/>
+        </ows20:HTTP>
+      </ows20:DCP>
+      <ows20:Parameter name="ParameterName">
+        <ows20:AllowedValues>
+          <ows20:Value>GetCapabilities.acceptFormats</ows20:Value>
+          <ows20:Value>GetCapabilities.acceptVersions</ows20:Value>
+          <ows20:Value>GetCapabilities.sections</ows20:Value>
+          <ows20:Value>GetRecordById.ElementSetName</ows20:Value>
+          <ows20:Value>GetRecordById.outputFormat</ows20:Value>
+          <ows20:Value>GetRecordById.outputSchema</ows20:Value>
+          <ows20:Value>GetRecords.CONSTRAINTLANGUAGE</ows20:Value>
+          <ows20:Value>GetRecords.ElementSetName</ows20:Value>
+          <ows20:Value>GetRecords.outputFormat</ows20:Value>
+          <ows20:Value>GetRecords.outputSchema</ows20:Value>
+          <ows20:Value>GetRecords.typeNames</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+    </ows20:Operation>
+    <ows20:Operation name="GetRecords">
+      <ows20:DCP>
+        <ows20:HTTP>
+          <ows20:Get xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg"/>
+          <ows20:Post xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg"/>
+        </ows20:HTTP>
+      </ows20:DCP>
+      <ows20:Parameter name="CONSTRAINTLANGUAGE">
+        <ows20:AllowedValues>
+          <ows20:Value>CQL_TEXT</ows20:Value>
+          <ows20:Value>FILTER</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="ElementSetName">
+        <ows20:AllowedValues>
+          <ows20:Value>brief</ows20:Value>
+          <ows20:Value>full</ows20:Value>
+          <ows20:Value>summary</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="outputFormat">
+        <ows20:AllowedValues>
+          <ows20:Value>application/atom+xml</ows20:Value>
+          <ows20:Value>application/json</ows20:Value>
+          <ows20:Value>application/xml</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="outputSchema">
+        <ows20:AllowedValues>
+          <ows20:Value>http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/</ows20:Value>
+          <ows20:Value>http://www.interlis.ch/INTERLIS2.3</ows20:Value>
+          <ows20:Value>http://www.opengis.net/cat/csw/3.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/cat/csw/csdgm</ows20:Value>
+          <ows20:Value>http://www.w3.org/2005/Atom</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="typeNames">
+        <ows20:AllowedValues>
+          <ows20:Value>csw:Record</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Constraint name="MaxRecordDefault">
+        <ows20:AllowedValues>
+          <ows20:Value>10</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Constraint>
+      <ows20:Constraint name="OpenSearchDescriptionDocument">
+        <ows20:AllowedValues>
+          <ows20:Value>http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg?mode=opensearch&amp;service=CSW&amp;version=3.0.0&amp;request=GetCapabilities</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Constraint>
+      <ows20:Constraint name="FederatedCatalogues">
+        <ows20:AllowedValues>
+          <ows20:Value>http://demo.pycsw.org/gisdata/csw</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Constraint>
+    </ows20:Operation>
+    <ows20:Operation name="GetRecordById">
+      <ows20:DCP>
+        <ows20:HTTP>
+          <ows20:Get xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg"/>
+          <ows20:Post xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg"/>
+        </ows20:HTTP>
+      </ows20:DCP>
+      <ows20:Parameter name="ElementSetName">
+        <ows20:AllowedValues>
+          <ows20:Value>brief</ows20:Value>
+          <ows20:Value>full</ows20:Value>
+          <ows20:Value>summary</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="outputFormat">
+        <ows20:AllowedValues>
+          <ows20:Value>application/atom+xml</ows20:Value>
+          <ows20:Value>application/json</ows20:Value>
+          <ows20:Value>application/xml</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+      <ows20:Parameter name="outputSchema">
+        <ows20:AllowedValues>
+          <ows20:Value>http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/</ows20:Value>
+          <ows20:Value>http://www.interlis.ch/INTERLIS2.3</ows20:Value>
+          <ows20:Value>http://www.opengis.net/cat/csw/3.0</ows20:Value>
+          <ows20:Value>http://www.opengis.net/cat/csw/csdgm</ows20:Value>
+          <ows20:Value>http://www.w3.org/2005/Atom</ows20:Value>
+        </ows20:AllowedValues>
+      </ows20:Parameter>
+    </ows20:Operation>
+    <ows20:Operation name="GetRepositoryItem">
+      <ows20:DCP>
+        <ows20:HTTP>
+          <ows20:Get xlink:type="simple" xlink:href="http://localhost/pycsw/csw.py?config=tests/suites/csw30/default.cfg"/>
+        </ows20:HTTP>
+      </ows20:DCP>
+    </ows20:Operation>
+    <ows20:Parameter name="service">
+      <ows20:AllowedValues>
+        <ows20:Value>CSW</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Parameter>
+    <ows20:Parameter name="version">
+      <ows20:AllowedValues>
+        <ows20:Value>2.0.2</ows20:Value>
+        <ows20:Value>3.0.0</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Parameter>
+    <ows20:Constraint name="CoreQueryables">
+      <ows20:AllowedValues>
+        <ows20:Value>csw:AnyText</ows20:Value>
+        <ows20:Value>dc:contributor</ows20:Value>
+        <ows20:Value>dc:creator</ows20:Value>
+        <ows20:Value>dc:date</ows20:Value>
+        <ows20:Value>dc:format</ows20:Value>
+        <ows20:Value>dc:identifier</ows20:Value>
+        <ows20:Value>dc:language</ows20:Value>
+        <ows20:Value>dc:publisher</ows20:Value>
+        <ows20:Value>dc:relation</ows20:Value>
+        <ows20:Value>dc:rights</ows20:Value>
+        <ows20:Value>dc:source</ows20:Value>
+        <ows20:Value>dc:subject</ows20:Value>
+        <ows20:Value>dc:title</ows20:Value>
+        <ows20:Value>dc:type</ows20:Value>
+        <ows20:Value>dct:abstract</ows20:Value>
+        <ows20:Value>dct:alternative</ows20:Value>
+        <ows20:Value>dct:modified</ows20:Value>
+        <ows20:Value>dct:spatial</ows20:Value>
+        <ows20:Value>ows:BoundingBox</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="FederatedCatalogues">
+      <ows20:AllowedValues>
+        <ows20:Value>http://demo.pycsw.org/gisdata/csw</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="MaxRecordDefault">
+      <ows20:AllowedValues>
+        <ows20:Value>10</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="PostEncoding">
+      <ows20:AllowedValues>
+        <ows20:Value>SOAP</ows20:Value>
+        <ows20:Value>XML</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="XPathQueryables">
+      <ows20:AllowedValues>
+        <ows20:Value>allowed</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/CoreQueryables">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/CoreSortables">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/DefaultSortingAlgorithm">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Filter-CQL">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Filter-FES-KVP-Advanced">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Filter-FES-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetCapabilities-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetDomain-KVP">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetDomain-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetRecordById-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetRecords-Async-KVP">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetRecords-Async-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetRecords-Basic-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetRecords-Distributed-KVP">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/GetRecords-Distributed-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Harvest-Async-KVP">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Harvest-Async-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Harvest-Basic-KVP">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Harvest-Basic-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Harvest-Periodic-KVP">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Harvest-Periodic-XML">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/OpenSearch">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/SupportedGMLVersions">
+      <ows20:AllowedValues>
+        <ows20:Value>http://www.opengis.net/gml</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+    <ows20:Constraint name="http://www.opengis.net/spec/csw/3.0/conf/Transaction">
+      <ows20:AllowedValues>
+        <ows20:Value>TRUE</ows20:Value>
+      </ows20:AllowedValues>
+    </ows20:Constraint>
+  </ows20:OperationsMetadata>
+  <ows20:Languages>
+    <ows20:Language>en</ows20:Language>
+  </ows20:Languages>
+  <fes20:Filter_Capabilities>
+    <fes20:Conformance>
+      <fes20:Constraint name="ImplementsQuery">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsAdHocQuery">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsFunctions">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsResourceld">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsMinStandardFilter">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsStandardFilter">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsMinSpatialFilter">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsSpatialFilter">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsMinTemporalFilter">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsTemporalFilter">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsVersionNav">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsSorting">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsExtendedOperators">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsMinimumXPath">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+      <fes20:Constraint name="ImplementsSchemaElementFunc">
+        <ows11:NoValues/>
+        <ows11:DefaultValue>TRUE</ows11:DefaultValue>
+      </fes20:Constraint>
+    </fes20:Conformance>
+    <fes20:Id_Capabilities>
+      <fes20:ResourceIdentifier name="csw30:id"/>
+    </fes20:Id_Capabilities>
+    <fes20:Scalar_Capabilities>
+      <fes20:LogicalOperators/>
+      <fes20:ComparisonOperators>
+        <fes20:ComparisonOperator name="PropertyIsBetween"/>
+        <fes20:ComparisonOperator name="PropertyIsEqualTo"/>
+        <fes20:ComparisonOperator name="PropertyIsGreaterThan"/>
+        <fes20:ComparisonOperator name="PropertyIsGreaterThanOrEqualTo"/>
+        <fes20:ComparisonOperator name="PropertyIsLessThan"/>
+        <fes20:ComparisonOperator name="PropertyIsLessThanOrEqualTo"/>
+        <fes20:ComparisonOperator name="PropertyIsLike"/>
+        <fes20:ComparisonOperator name="PropertyIsNotEqualTo"/>
+        <fes20:ComparisonOperator name="PropertyIsNull"/>
+      </fes20:ComparisonOperators>
+    </fes20:Scalar_Capabilities>
+    <fes20:Spatial_Capabilities>
+      <fes20:GeometryOperands>
+        <fes20:GeometryOperand name="gml:Point"/>
+        <fes20:GeometryOperand name="gml:LineString"/>
+        <fes20:GeometryOperand name="gml:Polygon"/>
+        <fes20:GeometryOperand name="gml:Envelope"/>
+      </fes20:GeometryOperands>
+      <fes20:SpatialOperators>
+        <fes20:SpatialOperator name="BBOX"/>
+        <fes20:SpatialOperator name="Beyond"/>
+        <fes20:SpatialOperator name="Contains"/>
+        <fes20:SpatialOperator name="Crosses"/>
+        <fes20:SpatialOperator name="Disjoint"/>
+        <fes20:SpatialOperator name="DWithin"/>
+        <fes20:SpatialOperator name="Equals"/>
+        <fes20:SpatialOperator name="Intersects"/>
+        <fes20:SpatialOperator name="Overlaps"/>
+        <fes20:SpatialOperator name="Touches"/>
+        <fes20:SpatialOperator name="Within"/>
+      </fes20:SpatialOperators>
+    </fes20:Spatial_Capabilities>
+    <fes20:Functions>
+      <fes20:Function name="length">
+        <fes20:Returns>xs:string</fes20:Returns>
+      </fes20:Function>
+      <fes20:Function name="lower">
+        <fes20:Returns>xs:string</fes20:Returns>
+      </fes20:Function>
+      <fes20:Function name="ltrim">
+        <fes20:Returns>xs:string</fes20:Returns>
+      </fes20:Function>
+      <fes20:Function name="rtrim">
+        <fes20:Returns>xs:string</fes20:Returns>
+      </fes20:Function>
+      <fes20:Function name="trim">
+        <fes20:Returns>xs:string</fes20:Returns>
+      </fes20:Function>
+      <fes20:Function name="upper">
+        <fes20:Returns>xs:string</fes20:Returns>
+      </fes20:Function>
+    </fes20:Functions>
+  </fes20:Filter_Capabilities>
+</csw30:Capabilities>


### PR DESCRIPTION
# Overview
In CSW 3, `service` and `version` parameters are optional (required in CSW 2.0.2).  This PR does deeper detection of CSW 2 vs. 3 requests and handles/sets `service` and `version` accordingly.

# Related Issue / Discussion
#544 
# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
