### PR TITLE
Improvements to dev workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,15 +63,18 @@ RUN adduser -D -u 1000 pycsw
 
 WORKDIR /tmp/pycsw
 
-COPY . .
-
-ENV PYCSW_CONFIG=/etc/pycsw/pycsw.cfg
+COPY requirements-standalone.txt requirements-pg.txt ./
 
 RUN pip3 install --upgrade pip setuptools \
   && pip3 install --requirement requirements-standalone.txt \
   && pip3 install --requirement requirements-pg.txt \
-  && pip3 install gunicorn \
-  && pip3 install . \
+  && pip3 install gunicorn
+
+COPY . .
+
+ENV PYCSW_CONFIG=/etc/pycsw/pycsw.cfg
+
+RUN pip3 install . \
   && mkdir /etc/pycsw \
   && mv docker/pycsw.cfg ${PYCSW_CONFIG} \
   && mkdir /var/lib/pycsw \

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -256,6 +256,19 @@ be printed to standard output.
    py.test -m functional -k 'harvesting' --functional-prefer-diffs
 
 
+Saving test results for disk
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The result of each functional test can be saved to disk by using the
+``--functional-save-results-directory`` option. Each result file is named
+after the test identifier it has when running with pytest.
+
+.. code:: bash
+
+   py.test -m functional -k 'not harvesting' --functional-save-results-directory=/tmp/pycsw-test-results
+
+
+
 Test coverage
 ^^^^^^^^^^^^^
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,11 @@ def pytest_addoption(parser):
              "expected values by using diffs instead of XML canonicalisation "
              "(the default)."
     )
+    parser.addoption(
+        "--functional-save-results-directory",
+        help="When running functional tests, save each test's result under "
+             "the input directory path."
+    )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Tihs PR refactors some stuff related to tests. Things that were changed:

- the --functional-prefer-diffs flag now causes full print of expected/result to be suppressed
- added a new functional-save-results-directory option to enable saving results to disk
- updated testing docs
- Dockerfile now separates installation of requirements in order to speed up build time (this still needs some work in order to really speed things up - to be continued later)

# Overview

# Related Issue / Discussion

These matters were discussed on gitter:
https://gitter.im/geopython/pycsw?at=5a04d049f257ad9109761a32

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
