### PR TITLE
improved dockerfile build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,19 +63,34 @@ RUN adduser -D -u 1000 pycsw
 
 WORKDIR /tmp/pycsw
 
-COPY requirements-standalone.txt requirements-pg.txt ./
+COPY \
+  requirements-standalone.txt \
+  requirements-pg.txt \
+  requirements-dev.txt \
+  requirements.txt \
+  ./
 
 RUN pip3 install --upgrade pip setuptools \
+  && pip3 install --requirement requirements.txt \
   && pip3 install --requirement requirements-standalone.txt \
   && pip3 install --requirement requirements-pg.txt \
   && pip3 install gunicorn
 
-COPY . .
+COPY pycsw pycsw/
+COPY bin bin/
+COPY setup.py .
+COPY MANIFEST.in .
+COPY VERSION.txt .
+COPY README.rst .
+
+RUN pip3 install .
+
+COPY tests tests/
+COPY docker docker/
 
 ENV PYCSW_CONFIG=/etc/pycsw/pycsw.cfg
 
-RUN pip3 install . \
-  && mkdir /etc/pycsw \
+RUN mkdir /etc/pycsw \
   && mv docker/pycsw.cfg ${PYCSW_CONFIG} \
   && mkdir /var/lib/pycsw \
   && chown pycsw:pycsw /var/lib/pycsw \


### PR DESCRIPTION
This PR has a couple of changes to the `Dockerfile` that deal with separating `COPY` and `RUN` instructions. They make it possible to prevent [cache busting](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#build-cache) and make
build times smaller. This is mainly useful during development

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines