### PR TITLE
Issue 556

### DIFF
--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -877,17 +877,14 @@ class Csw2(object):
 
         if int(matched) == 0:
             returned = nextrecord = '0'
+        elif int(matched) < int(self.parent.kvp['startposition']):
+            returned = nextrecord = '0'
+        elif int(matched) <= int(self.parent.kvp['startposition']) + int(self.parent.kvp['maxrecords']) - 1:
+            returned = str(int(matched) - int(self.parent.kvp['startposition']) + 1)
+            nextrecord = '0'
         else:
-            if int(matched) < int(self.parent.kvp['maxrecords']):
-                returned = matched
-                nextrecord = '0'
-            else:
-                returned = str(self.parent.kvp['maxrecords'])
-                if int(self.parent.kvp['startposition']) + int(self.parent.kvp['maxrecords']) >= int(matched):
-                    nextrecord = '0'
-                else:
-                    nextrecord = str(int(self.parent.kvp['startposition']) + \
-                    int(self.parent.kvp['maxrecords']))
+            returned = str(self.parent.kvp['maxrecords'])
+            nextrecord = str(int(self.parent.kvp['startposition']) + int(self.parent.kvp['maxrecords']))
 
         LOGGER.debug('Results: matched: %s, returned: %s, next: %s',
         matched, returned, nextrecord)

--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -877,7 +877,7 @@ class Csw2(object):
 
         if int(matched) == 0:
             returned = nextrecord = '0'
-        elif int(maxRecords) == 0:
+        elif int(self.parent.kvp['maxrecords']) == 0:
             returned = nextrecord = '0'
         elif int(matched) < int(self.parent.kvp['startposition']):
             returned = nextrecord = '0'

--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -877,6 +877,8 @@ class Csw2(object):
 
         if int(matched) == 0:
             returned = nextrecord = '0'
+        elif int(maxRecords) == 0:
+            returned = nextrecord = '0'
         elif int(matched) < int(self.parent.kvp['startposition']):
             returned = nextrecord = '0'
         elif int(matched) <= int(self.parent.kvp['startposition']) + int(self.parent.kvp['maxrecords']) - 1:

--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -878,9 +878,11 @@ class Csw2(object):
         if int(matched) == 0:
             returned = nextrecord = '0'
         elif int(self.parent.kvp['maxrecords']) == 0:
-            returned = nextrecord = '0'
+            returned = '0'
+            nextrecord = '1'
         elif int(matched) < int(self.parent.kvp['startposition']):
-            returned = nextrecord = '0'
+            returned = '0'
+            nextrecord = '1'
         elif int(matched) <= int(self.parent.kvp['startposition']) + int(self.parent.kvp['maxrecords']) - 1:
             returned = str(int(matched) - int(self.parent.kvp['startposition']) + 1)
             nextrecord = '0'

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -869,7 +869,7 @@ class Csw3(object):
 
         if int(matched) == 0:
             returned = nextrecord = '0'
-        elif int(maxRecords) == 0:
+        elif int(self.parent.kvp['maxrecords']) == 0:
             returned = nextrecord = '0'
         elif int(matched) < int(self.parent.kvp['startposition']):
             returned = nextrecord = '0'

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -869,17 +869,14 @@ class Csw3(object):
 
         if int(matched) == 0:
             returned = nextrecord = '0'
+        elif int(matched) < int(self.parent.kvp['startposition']):
+            returned = nextrecord = '0'
+        elif int(matched) <= int(self.parent.kvp['startposition']) + int(self.parent.kvp['maxrecords']) - 1:
+            returned = str(int(matched) - int(self.parent.kvp['startposition']) + 1)
+            nextrecord = '0'
         else:
-            if int(matched) < int(self.parent.kvp['maxrecords']):
-                returned = matched
-                nextrecord = '0'
-            else:
-                returned = str(self.parent.kvp['maxrecords'])
-                if int(self.parent.kvp['startposition']) + int(self.parent.kvp['maxrecords']) >= int(matched):
-                    nextrecord = '0'
-                else:
-                    nextrecord = str(int(self.parent.kvp['startposition']) + \
-                    int(self.parent.kvp['maxrecords']))
+            returned = str(self.parent.kvp['maxrecords'])
+            nextrecord = str(int(self.parent.kvp['startposition']) + int(self.parent.kvp['maxrecords']))
 
         LOGGER.debug('Results: matched: %s, returned: %s, next: %s',
         matched, returned, nextrecord)

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -869,6 +869,8 @@ class Csw3(object):
 
         if int(matched) == 0:
             returned = nextrecord = '0'
+        elif int(maxRecords) == 0:
+            returned = nextrecord = '0'
         elif int(matched) < int(self.parent.kvp['startposition']):
             returned = nextrecord = '0'
         elif int(matched) <= int(self.parent.kvp['startposition']) + int(self.parent.kvp['maxrecords']) - 1:

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -870,9 +870,11 @@ class Csw3(object):
         if int(matched) == 0:
             returned = nextrecord = '0'
         elif int(self.parent.kvp['maxrecords']) == 0:
-            returned = nextrecord = '0'
+            returned = '0'
+            nextrecord = '1'
         elif int(matched) < int(self.parent.kvp['startposition']):
-            returned = nextrecord = '0'
+            returned = '0'
+            nextrecord = '1'
         elif int(matched) <= int(self.parent.kvp['startposition']) + int(self.parent.kvp['maxrecords']) - 1:
             returned = str(int(matched) - int(self.parent.kvp['startposition']) + 1)
             nextrecord = '0'

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -870,11 +870,9 @@ class Csw3(object):
         if int(matched) == 0:
             returned = nextrecord = '0'
         elif int(self.parent.kvp['maxrecords']) == 0:
-            returned = '0'
-            nextrecord = '1'
+            returned = nextrecord = '0'
         elif int(matched) < int(self.parent.kvp['startposition']):
-            returned = '0'
-            nextrecord = '1'
+            returned = nextrecord = '0'
         elif int(matched) <= int(self.parent.kvp['startposition']) + int(self.parent.kvp['maxrecords']) - 1:
             returned = str(int(matched) - int(self.parent.kvp['startposition']) + 1)
             nextrecord = '0'

--- a/tests/functionaltests/suites/cite/expected/post_0c976d98-c896-4b10-b1fe-a22ef50434e7.xml
+++ b/tests/functionaltests/suites/cite/expected/post_0c976d98-c896-4b10-b1fe-a22ef50434e7.xml
@@ -2,5 +2,5 @@
 <!-- PYCSW_VERSION -->
 <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.2" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
   <csw:SearchStatus timestamp="PYCSW_TIMESTAMP"/>
-  <csw:SearchResults nextRecord="1" numberOfRecordsMatched="11" numberOfRecordsReturned="0" recordSchema="http://www.opengis.net/cat/csw/2.0.2"/>
+  <csw:SearchResults nextRecord="0" numberOfRecordsMatched="11" numberOfRecordsReturned="0" recordSchema="http://www.opengis.net/cat/csw/2.0.2"/>
 </csw:GetRecordsResponse>

--- a/tests/functionaltests/suites/cite/expected/post_0c976d98-c896-4b10-b1fe-a22ef50434e7.xml
+++ b/tests/functionaltests/suites/cite/expected/post_0c976d98-c896-4b10-b1fe-a22ef50434e7.xml
@@ -2,5 +2,5 @@
 <!-- PYCSW_VERSION -->
 <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.2" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
   <csw:SearchStatus timestamp="PYCSW_TIMESTAMP"/>
-  <csw:SearchResults nextRecord="0" numberOfRecordsMatched="11" numberOfRecordsReturned="0" recordSchema="http://www.opengis.net/cat/csw/2.0.2"/>
+  <csw:SearchResults nextRecord="1" numberOfRecordsMatched="11" numberOfRecordsReturned="0" recordSchema="http://www.opengis.net/cat/csw/2.0.2"/>
 </csw:GetRecordsResponse>

--- a/tests/functionaltests/suites/default/expected/post_GetRecords-end.xml
+++ b/tests/functionaltests/suites/default/expected/post_GetRecords-end.xml
@@ -2,7 +2,7 @@
 <!-- PYCSW_VERSION -->
 <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.2" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
   <csw:SearchStatus timestamp="PYCSW_TIMESTAMP"/>
-  <csw:SearchResults nextRecord="0" numberOfRecordsMatched="12" numberOfRecordsReturned="5" recordSchema="http://www.opengis.net/cat/csw/2.0.2" elementSet="full">
+  <csw:SearchResults nextRecord="0" numberOfRecordsMatched="12" numberOfRecordsReturned="3" recordSchema="http://www.opengis.net/cat/csw/2.0.2" elementSet="full">
     <csw:Record>
     <dc:identifier>urn:uuid:a06af396-3105-442d-8b40-22b57a90d2f2</dc:identifier>
     <dc:type>http://purl.org/dc/dcmitype/Image</dc:type>


### PR DESCRIPTION
# Overview

The value of the `numberOfRecordsReturned` attribute returned with a GetRecords request was incorrect if the number of record left in the catalogue is less than the `maxrecord` parameter passed with the request, but the number of `matched` records is greater than `maxrecords`.  This can happen if the `startposition` parameter specified with the GetRecords request is close to the number of matched records, such that `(startposition+maxrecords) > matched`.

The csw2.py and csw3.py files both had code which allowed: `numberOfRecordsReturned=maxrecords` if `(startposition+maxrecords) > matched`

With functional testing, the changes also highlighted that one of the functional tests expected incorrect reponse XML.  The test, `default_post_GetRecords-end`, has had its expected XML modified to reflect the correct expected attribute value. 

Also, when `maxRecords=0`, the behaviour is the same as `resultType=hits` and no records are returned.  In this case, `nextRecord` and `numberOfRecordsReturned` should be returned as 0.  Making sure this happens also impacted a CITE functional test: `post_0c976d98-c896-4b10-b1fe-a22ef50434e7.xml` which specifies `maxRecords=0`, but expected `nextRecord=1`.  This has been amended to expect `nextRecord=0`.

# Related Issue / Discussion

There are no unit tests for this piece of the code.  Might it be useful to create some?

The way that the code determines the number of returned records is perhaps a little reckless?  It would probably be safer to count the number of records, then assign that number to the attribute, rather than do the calculation based on input parameters and the total number of matched records.  This might be a bigger piece of work, however.  I have not investigated how this approach could be implemented.

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

I'd like to contribute this bugfix, relating to the reported value of numberOfRecordsReturned during GetReocrds requests, to the pycsw project. I confirm that my contributions to pycsw will be compatible with the pycsw licence guidelines at the time of contribution.
