### PR TITLE
Rename 'async' property to fix SyntaxError with Python 3.7.

### DIFF
--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -1934,7 +1934,7 @@ class Csw2(object):
 
             node2.text = self.parent.request
 
-        if self.parent.async:
+        if self.parent.asynchronous:
             etree.SubElement(node, util.nspath_eval('csw:RequestId',
             self.parent.context.namespaces)).text = self.kvp['requestid']
 

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -2009,7 +2009,7 @@ class Csw3(object):
 
             node2.text = self.parent.request
 
-        if self.parent.async:
+        if self.parent.asynchronous:
             etree.SubElement(node, util.nspath_eval('csw30:RequestId',
             self.parent.context.namespaces)).text = self.parent.kvp['requestid']
 

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -75,7 +75,7 @@ class Csw(object):
         self.kvp = {}
 
         self.mode = 'csw'
-        self.async = False
+        self.asynchronous = False
         self.soap = False
         self.request = None
         self.exception = False
@@ -539,7 +539,7 @@ class Csw(object):
             if 'responsehandler' in self.kvp:
                 # set flag to process asynchronously
                 import threading
-                self.async = True
+                self.asynchronous = True
                 request_id = self.kvp.get('requestid', None)
                 if request_id is None:
                     import uuid
@@ -552,7 +552,7 @@ class Csw(object):
             elif self.kvp['request'] == 'GetDomain':
                 self.response = self.iface.getdomain()
             elif self.kvp['request'] == 'GetRecords':
-                if self.async:  # process asynchronously
+                if self.asynchronous:  # process asynchronously
                     threading.Thread(target=self.iface.getrecords).start()
                     self.response = self.iface._write_acknowledgement()
                 else:
@@ -564,7 +564,7 @@ class Csw(object):
             elif self.kvp['request'] == 'Transaction':
                 self.response = self.iface.transaction()
             elif self.kvp['request'] == 'Harvest':
-                if self.async:  # process asynchronously
+                if self.asynchronous:  # process asynchronously
                     threading.Thread(target=self.iface.harvest).start()
                     self.response = self.iface._write_acknowledgement()
                 else:


### PR DESCRIPTION
# Overview

Rename `async` property to `asynchronous` to fix `SyntaxError` with Python 3.7.

`async` is now a reserved keyword in Python 3.7.

# Related Issue / Discussion

Fixes: #570

# Additional Information

> Backwards incompatible syntax changes:
> 
>  * [async](https://docs.python.org/3/reference/compound_stmts.html#async) and [await](https://docs.python.org/3/reference/expressions.html#await) are now reserved keywords.

https://docs.python.org/3/whatsnew/3.7.html

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
