### PR TITLE
fix to handle '/' or '\\'

### DIFF
--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -184,7 +184,7 @@ class Csw(object):
             try:
                 import imp
                 module = self.config.get('repository', 'mappings')
-                if '/' in module:  # filepath
+                if os.sep in module:  # filepath
                     modulename = '%s' % os.path.splitext(module)[0].replace(
                         os.sep, '.')
                     mappings = imp.load_source(modulename, module)


### PR DESCRIPTION
# Overview
simply use os.sep instead of '/' to handle Windows or Linux  systems

# Related Issue / Discussion
this fixes issue in Windows
Could not load custom mappings: Import by filename is not supported.
Traceback (most recent call last):
  File "D:\work\geonode\env_10\lib\site-packages\pycsw\server.py", line 192, in __init__
    mappings = __import__(module, fromlist=[''])
ImportError: Import by filename is not supported.


# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ *] I'd like to contribute bugfix  to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [* ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
