### PR TITLE
Update pyproj to 1.9.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 geolinks==0.2.0
 lxml==3.6.2
 OWSLib==0.16.0
-pyproj==1.9.5.1
+pyproj==1.9.6
 Shapely==1.5.17
 six==1.10.0
 xmltodict==0.10.2


### PR DESCRIPTION
# Overview

pyproj<1.9.6 does not compile in Python 3.7.

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
