### PR TITLE
remove Python 3.4 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,6 @@ jobs:
       after_success: codecov --disable search --flags unittests
 
     - stage: unit-test
-      python: "3.4"
-      env: TOXENV=py34-sqlite
-      install: pip install codecov tox
-      script: tox -- --exitfirst -m unit
-      after_success: codecov --disable search --flags unittests
-
-    - stage: unit-test
       python: "3.5"
       env: TOXENV=py35-sqlite
       install: pip install codecov tox
@@ -45,13 +38,6 @@ jobs:
     - stage: integration-test
       python: "2.7"
       env: TOXENV=py27-sqlite
-      install: pip install codecov tox
-      script: tox -- --exitfirst -m functional -k 'not harvesting'
-      after_success: codecov --disable search --flags integrationtests
-
-    - stage: integration-test
-      python: "3.4"
-      env: TOXENV=py34-sqlite
       install: pip install codecov tox
       script: tox -- --exitfirst -m functional -k 'not harvesting'
       after_success: codecov --disable search --flags integrationtests

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py27,py34,py35,py36,py37}-sqlite
+envlist = {py27,py35,py36,py37}-sqlite
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
# Overview
Along the same lines as https://github.com/geopython/OWSLib/pull/570, removing 3.4.

# Related Issue / Discussion
NA
# Additional Information
NA
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
