### PR TITLE
Fix SyntaxWarning issues with Python 3.8.

### DIFF
--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -714,7 +714,7 @@ class Csw2(object):
             LOGGER.debug('OpenSearch Geo/Time parameters detected.')
             self.parent.kvp['constraintlanguage'] = 'FILTER'
             tmp_filter = opensearch.kvp2filterxml(self.parent.kvp, self.parent.context)
-            if tmp_filter is not "":
+            if tmp_filter != "":
                 self.parent.kvp['constraint'] = tmp_filter
                 LOGGER.debug('OpenSearch Geo/Time parameters to Filter: %s.', self.parent.kvp['constraint'])
 

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -742,7 +742,7 @@ class Csw3(object):
             except Exception as err:
                 return self.exceptionreport('InvalidParameterValue', 'bbox', str(err))
 
-            if tmp_filter is not "":
+            if tmp_filter != "":
                 self.parent.kvp['constraint'] = tmp_filter
                 LOGGER.debug('OpenSearch Geo/Time parameters to Filter: %s.', self.parent.kvp['constraint'])
 

--- a/pycsw/opensearch.py
+++ b/pycsw/opensearch.py
@@ -350,7 +350,7 @@ def kvp2filterxml(kvp, context):
                 if time_list == ['', '']:
                     par_count -= 1
                 # One of two is empty
-                elif time_list[1] is '':
+                elif time_list[1] == '':
                     time_element = etree.Element(util.nspath_eval('ogc:PropertyIsGreaterThanOrEqualTo',
                                 context.namespaces))
                     el = etree.Element(util.nspath_eval('ogc:PropertyName',


### PR DESCRIPTION
The addition of Python 3.8 as supported interpreter in Debian revealed a few SyntaxWarning issues:
```
/usr/lib/python3/dist-packages/pycsw/ogc/csw/csw2.py:717: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if tmp_filter is not "":
/usr/lib/python3/dist-packages/pycsw/ogc/csw/csw3.py:745: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if tmp_filter is not "":
/usr/lib/python3/dist-packages/pycsw/opensearch.py:353: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif time_list[1] is '':
```

- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines