### PR TITLE
refactor Dockerfile in order to use python:3.8-slim-buster as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Contributors: Arnulf Heimsbakk <aheimsbakk@met.no>
 #               Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2017 Ricardo Garcia Silva
+# Copyright (c) 2020 Ricardo Garcia Silva
 # Copyright (c) 2020 Massimo Di Stefano
 #
 #
@@ -33,66 +33,40 @@
 #
 # =================================================================
 
-FROM alpine:3.11
+FROM python:3.8-slim-buster
 LABEL maintainer="massimods@met.no,aheimsbakk@met.no"
 
-ARG PYCSW_HOME=/tmp/pycsw
+RUN apt-get update && apt-get install --yes \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
-ENV PYCSW_CONFIG=/etc/pycsw/pycsw.cfg
+RUN adduser --uid 1000 --gecos '' --disabled-password pycsw
 
-COPY . ${PYCSW_HOME}
+WORKDIR /home/pycsw/pycsw
 
-RUN apk add binutils \
-  && ${PYCSW_HOME}/docker/min-apk \
-    ca-certificates \
-    geos \
-    libpq \
-    libxml2 \
-    libxslt \
-    proj \
-    proj-util \
-    python3 \
-    sqlite \
-  && apk del binutils
+RUN chown --recursive pycsw:pycsw .
 
+# initially copy only the requirements files
+COPY --chown=pycsw \
+    requirements.txt \
+    requirements-standalone.txt \
+    ./
 
-RUN apk add --no-cache --virtual .build-deps \
-    build-base \
-    geos-dev \
-    libxml2-dev \
-    libxslt-dev \
-    postgresql-dev \
-    proj-dev \
-    python3-dev \
-  && pip3 install --upgrade pip setuptools \
-  && pip3 install wheel \
-  && pip3 install gunicorn \
-  && pip3 install --requirement ${PYCSW_HOME}/requirements.txt \
-  && pip3 install --requirement ${PYCSW_HOME}/requirements-standalone.txt \
-  && pip3 install --requirement ${PYCSW_HOME}/requirements-pg.txt \
-  && apk del .build-deps
+RUN python3 -m pip install \
+    --requirement requirements.txt \
+    --requirement requirements-standalone.txt \
+    psycopg2-binary \
+    gunicorn
 
-ADD docker/pycsw.cfg ${PYCSW_CONFIG}
-ADD docker/entrypoint.py /usr/local/bin/entrypoint.py
+COPY --chown=pycsw . .
 
-WORKDIR ${PYCSW_HOME}
-
-RUN pip3 install . \
-  && adduser -D -u 1000 pycsw \
-  && cp -r ${PYCSW_HOME}/tests /home/pycsw \
-  && chown -R pycsw:pycsw /home/pycsw/* \
-  && rm -rf /usr/lib/python3*/*/tests \
-  && rm -rf /usr/lib/python3*/ensurepip \
-  && rm -rf /usr/lib/python3*/idlelib \
-  && rm -f /usr/lib/python3*/distutils/command/*exe \
-  && rm -rf /usr/share/man/* \
-  && rm -fr ${PYCSW_HOME} \
-  && find /usr/lib -name  "*.pyc" -o -name "*.pyo" -delete
+RUN python3 -m pip install --editable .
 
 WORKDIR /home/pycsw
 
 EXPOSE 8000
 
 USER pycsw
+ENV PYCSW_CONFIG=/home/pycsw/pycsw/docker/pycsw.cfg
 
-ENTRYPOINT [ "python3", "/usr/local/bin/entrypoint.py" ]
+ENTRYPOINT [ "python3", "/home/pycsw/pycsw/docker/entrypoint.py" ]


### PR DESCRIPTION
# Overview
This PR modifies pycsw's `Dockerfile` in order to use an official python-debian image as the base for building.

# Related Issue / Discussion

#614

# Additional Information

My percieved advantages of this approach vs the current implementation (base image based on alpine linux):

-  Faster cold build time, since we can use python wheels - no need to compile anything
-  Similar environment to CI and non-docker environments (seems to me that alpine is not common outside of embedded and containers)
-  Being based on the official Python repos, it is easier to build and test pycsw with other python versions, it is just a matter of changing the dockerfile base image


In addition to replacing alpine with an offcial python image based on current debian, I've made some other notorious modifications to the `Dockerfile`:

-  Rearrange dockerfile commands in order to make use of the docker caching mechanism. This makes rebuilding the image much faster whenever a change is made in the pycsw codebase - This change is orthogonal to the image being used as a base so we should add it regardless of what final decision is made on the alpine vs. debian front

-  Install pycsw in editable mode, which allows easier dev workflow - we can run a container and mount the code dir

   Additionally, leave all files in place instead of moving pycsw config to `/etc/pycsw` and moving `entrypoint.py` to `/usr/local/bin` - this is also in order to allow a friendlier dev environment


-  Install the `psycopg2-binary` dependency instead of `psycopg2`. This change has been made in the `Dockerfile` and not on the `requirements-pg.txt` file in order to be less intrusive


Comparison between the proposed implementation and current master:

-  Current master (based on alpine)

   -  Builds are slow
   -  image is small
   -  Rebuilds are slow

   ```
   time docker build -t geopython/pycsw:master -f Dockerfile .
   # build time: 2m50s
   # image size: 172MB
   # rebuild time after a change in pycsw's codebase: 2m58s
   ```

-  This implementation (based on debian)

   -  Builds are fast
   -  image is bigger
   -  Rebuilds are fast

   ```
   docker rmi geopython/pycsw:with-dev python:3.8-slim-buster
   time docker build -t geopython/pycsw:without-dev -f Dockerfile.test2 .
   # build time: 30s
   # image size: 311MB
   # rebuild time after a change in pycsw's codebase: 5s
   ```

IMO an image size of 311MB is still pretty modest and, all things considered, [absolute image size is probably not so relevant anyway](https://semaphoreci.com/blog/2018/03/14/docker-image-size.html).

This implementation builds significantly faster and uses a more flexible and familiar base image. It also opens up the door to other niceties:

-  It is now easier to dev inside a docker container, for example with:

   ```
   # using the container for dev work by bind mounting the code dir inside the container
   # changes to pycsw are automatically available inside the container
   docker run \
       --name pycsw-dev \
       --rm \
       -ti \
       -v $(pwd)/pycsw:/home/pycsw/pycsw/pycsw \
       {image}

   # reload the gunicorn server by sending the HUP signal (it is pid 1 inside the container)
   docker exec -ti pycsw-dev /bin/bash -c 'kill -HUP 1'
   ```

-  It is now easier to run tests inside a docker container:

   ```
   # running tests inside container (requires installation of the dev requirements)
   docker run \
       --rm \
       -ti \
       --user root \
       --entrypoint /bin/bash \
       {image} \
       -c 'cd pycsw && pip install requirements-dev.txt && su pycsw -c "pytest -x -v -k \"not harvesting and not distributed\""'
   ```




# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
