### PR TITLE
update docker-compose to PostgreSQL 11

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -48,7 +48,7 @@ services:
 
   db:
     container_name: db
-    image: mdillon/postgis:9.6-alpine
+    image: mdillon/postgis:11-alpine
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: mypass

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -48,7 +48,7 @@ services:
 
   db:
     container_name: db
-    image: mdillon/postgis:11-alpine
+    image: postgis/postgis:12-3.0-alpine
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: mypass


### PR DESCRIPTION
# Overview
This PR updates pycsw's docker compose setup to work with PostgreSQL 11.

# Related Issue / Discussion
NA

# Additional Information
NA
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
