### PR TITLE
Adding a helm chart based on current kubernetes configuration

### DIFF
--- a/docker/helm/Chart.yaml
+++ b/docker/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: cs
+description: A Helm chart for Kubernetes of the Catalogue Server (CS)
+version: 0.0.1
+appVersion: 2.4.2

--- a/docker/helm/README.md
+++ b/docker/helm/README.md
@@ -1,0 +1,13 @@
+Chart for the Catalogue Server (CS) bundling all services
+
+Debug with:
+
+```bash
+helm install --dry-run --debug pycsw .
+```
+
+Deploy with:
+
+```bash
+helm install pycsw .
+```

--- a/docker/helm/templates/db-data-persistentvolumeclaim.yaml
+++ b/docker/helm/templates/db-data-persistentvolumeclaim.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: db-data
+  name: db-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+status: {}

--- a/docker/helm/templates/db-deployment.yaml
+++ b/docker/helm/templates/db-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: db
+  name: db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: db
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        io.kompose.service: db
+    spec:
+      containers:
+      - env:
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        - name: POSTGRES_DB
+          value: pycsw
+        - name: POSTGRES_PASSWORD
+          value: mypass
+        - name: POSTGRES_USER
+          value: postgres
+        image: postgis/postgis:12-3.0-alpine
+        name: db
+        ports:
+        - containerPort: 5432
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data/pgdata
+          name: db-data
+      restartPolicy: Always
+      volumes:
+      - name: db-data
+        persistentVolumeClaim:
+          claimName: db-data
+status: {}

--- a/docker/helm/templates/db-service.yaml
+++ b/docker/helm/templates/db-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: db
+  name: db
+spec:
+  ports:
+  - name: "5432"
+    port: 5432
+    targetPort: 5432
+  selector:
+    io.kompose.service: db
+status:
+  loadBalancer: {}

--- a/docker/helm/templates/pycsw-configmap.yaml
+++ b/docker/helm/templates/pycsw-configmap.yaml
@@ -1,0 +1,121 @@
+apiVersion: v1
+data:
+  pycsw.cfg: |+
+    # =================================================================
+    #
+    # Authors: Tom Kralidis <tomkralidis@gmail.com>
+    #          Ricardo Garcia Silva <ricardo.garcia.silva@gmail.com>
+    #
+    # Copyright (c) 2015 Tom Kralidis
+    # Copyright (c) 2017 Ricardo Garcia Silva
+    #
+    # Permission is hereby granted, free of charge, to any person
+    # obtaining a copy of this software and associated documentation
+    # files (the "Software"), to deal in the Software without
+    # restriction, including without limitation the rights to use,
+    # copy, modify, merge, publish, distribute, sublicense, and/or sell
+    # copies of the Software, and to permit persons to whom the
+    # Software is furnished to do so, subject to the following
+    # conditions:
+    #
+    # The above copyright notice and this permission notice shall be
+    # included in all copies or substantial portions of the Software.
+    #
+    # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    # OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    # HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    # OTHER DEALINGS IN THE SOFTWARE.
+    #
+    # =================================================================
+
+    [server]
+    home=/home/pycsw
+    url=${PYCSW_SERVER_URL}
+    mimetype=application/xml; charset=UTF-8
+    encoding=UTF-8
+    language=en-US
+    maxrecords=10
+    loglevel=DEBUG
+    logfile=
+    #ogc_schemas_base=http://foo
+    #federatedcatalogues=http://catalog.data.gov/csw
+    #pretty_print=true
+    #gzip_compresslevel=8
+    #domainquerytype=range
+    #domaincounts=true
+    #spatial_ranking=true
+    profiles=apiso
+
+    [manager]
+    transactions=false
+    allowed_ips=127.0.0.1
+    #csw_harvest_pagesize=10
+
+    [metadata:main]
+    identification_title=pycsw Geospatial Catalogue
+    identification_abstract=pycsw is an OGC CSW server implementation written in Python
+    identification_keywords=catalogue,discovery,metadata
+    identification_keywords_type=theme
+    identification_fees=None
+    identification_accessconstraints=None
+    provider_name=Organization Name
+    provider_url=https://pycsw.org/
+    contact_name=Lastname, Firstname
+    contact_position=Position Title
+    contact_address=Mailing Address
+    contact_city=City
+    contact_stateorprovince=Administrative Area
+    contact_postalcode=Zip or Postal Code
+    contact_country=Country
+    contact_phone=+xx-xxx-xxx-xxxx
+    contact_fax=+xx-xxx-xxx-xxxx
+    contact_email=Email Address
+    contact_url=Contact URL
+    contact_hours=Hours of Service
+    contact_instructions=During hours of service.  Off on weekends.
+    contact_role=pointOfContact
+
+    [repository]
+    # sqlite
+    #database=sqlite:////home/pycsw/tests/functionaltests/suites/cite/data/cite.db
+    # postgres
+    database=postgresql://postgres:mypass@db/pycsw
+    # mysql
+    #database=mysql://username:password@localhost/pycsw?charset=utf8
+    #mappings=path/to/mappings.py
+    table=records
+    #filter=type = 'http://purl.org/dc/dcmitype/Dataset'
+
+    [metadata:inspire]
+    enabled=true
+    languages_supported=eng,gre
+    default_language=eng
+    date=YYYY-MM-DD
+    gemet_keywords=Utility and governmental services
+    conformity_service=notEvaluated
+    contact_name=Organization Name
+    contact_email=Email Address
+    temp_extent=YYYY-MM-DD/YYYY-MM-DD
+
+kind: ConfigMap
+metadata:
+  creationTimestamp: "2020-10-12T20:12:04Z"
+  managedFields:
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:data:
+        .: {}
+        f:pycsw_config: {}
+    manager: kubectl
+    operation: Update
+    time: "2020-10-12T20:12:04Z"
+  name: pycsw-configmap
+  namespace: default
+  resourceVersion: "192581"
+  selfLink: /api/v1/namespaces/default/configmaps/pycsw-configmap
+  uid: 95a9327a-0091-4f07-abf9-093f59dc3a24

--- a/docker/helm/templates/pycsw-deployment.yaml
+++ b/docker/helm/templates/pycsw-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: pycsw
+  name: pycsw
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: pycsw
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        io.kompose.service: pycsw
+    spec:
+      containers:
+      - env:
+        - name: PYCSW_SERVER_URL
+          value: http://localhost:8000
+        image: 'geopython/pycsw:latest'
+        name: pycsw
+        ports:
+        - containerPort: 8000
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/pycsw
+          name: pycsw-config
+      restartPolicy: Always
+      volumes:
+      - name: pycsw-config
+        configMap:
+          name: pycsw-configmap
+status: {}

--- a/docker/helm/templates/pycsw-service.yaml
+++ b/docker/helm/templates/pycsw-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: pycsw
+  name: pycsw
+spec:
+  type: NodePort
+  ports:
+    - port: 8000
+      nodePort: 30000
+  selector:
+    io.kompose.service: pycsw
+status:
+  loadBalancer: {}


### PR DESCRIPTION
# Overview
This pull request adds simple helm chart support for current kubernetes configuration

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
