### PR TITLE
Keeping alpine dockerfile separate before moving to debian based images

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,99 @@
+# =================================================================
+# Authors: Ricardo Garcia Silva <ricardo.garcia.silva@gmail.com>
+# Authors: Massimo Di Stefano <epiesasha@me.com>
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#
+# Contributors: Arnulf Heimsbakk <aheimsbakk@met.no>
+#               Tom Kralidis <tomkralidis@gmail.com>
+#
+# Copyright (c) 2017 Ricardo Garcia Silva
+# Copyright (c) 2020 Massimo Di Stefano
+# Copyright (c) 2020 Tom Kralidis
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+#
+# =================================================================
+
+FROM alpine:3.11
+LABEL maintainer="massimods@met.no,aheimsbakk@met.no,tommkralidis@gmail.com"
+
+ARG PYCSW_HOME=/tmp/pycsw
+
+ENV PYCSW_CONFIG=/etc/pycsw/pycsw.cfg
+
+COPY . ${PYCSW_HOME}
+
+RUN apk add binutils \
+  && ${PYCSW_HOME}/docker/min-apk \
+    ca-certificates \
+    geos \
+    libpq \
+    libxml2 \
+    libxslt \
+    proj \
+    proj-util \
+    python3 \
+    sqlite \
+  && apk del binutils
+
+
+RUN apk add --no-cache --virtual .build-deps \
+    build-base \
+    geos-dev \
+    libxml2-dev \
+    libxslt-dev \
+    postgresql-dev \
+    proj-dev \
+    python3-dev \
+  && pip3 install --upgrade pip setuptools \
+  && pip3 install wheel \
+  && pip3 install gunicorn \
+  && pip3 install --requirement ${PYCSW_HOME}/requirements.txt \
+  && pip3 install --requirement ${PYCSW_HOME}/requirements-standalone.txt \
+  && pip3 install --requirement ${PYCSW_HOME}/requirements-pg.txt \
+  && apk del .build-deps
+
+ADD docker/pycsw.cfg ${PYCSW_CONFIG}
+ADD docker/entrypoint.py /usr/local/bin/entrypoint.py
+
+WORKDIR ${PYCSW_HOME}
+
+RUN pip3 install . \
+  && adduser -D -u 1000 pycsw \
+  && cp -r ${PYCSW_HOME}/tests /home/pycsw \
+  && chown -R pycsw:pycsw /home/pycsw/* \
+  && rm -rf /usr/lib/python3*/*/tests \
+  && rm -rf /usr/lib/python3*/ensurepip \
+  && rm -rf /usr/lib/python3*/idlelib \
+  && rm -f /usr/lib/python3*/distutils/command/*exe \
+  && rm -rf /usr/share/man/* \
+  && rm -fr ${PYCSW_HOME} \
+  && find /usr/lib -name  "*.pyc" -o -name "*.pyo" -delete
+
+WORKDIR /home/pycsw
+
+EXPOSE 8000
+
+USER pycsw
+
+ENTRYPOINT [ "python3", "/usr/local/bin/entrypoint.py" ]


### PR DESCRIPTION
# Overview

Before merging #615 we should keep an alpine version for transitioning

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
