### PR TITLE
add env interpolation on Docker startup

### DIFF
--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -50,6 +50,7 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.exc import ProgrammingError
 
 from pycsw.core import admin
+from pycsw.server import EnvInterpolation
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +168,7 @@ if __name__ == "__main__":
              "Defaults to False."
     )
     args = parser.parse_args()
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=EnvInterpolation())
     config.read(os.getenv("PYCSW_CONFIG"))
     try:
         level = config.get("server", "loglevel").upper()


### PR DESCRIPTION
# Overview
This PR (following on from #625) adds environment interpolation on docker startup.

# Related Issue / Discussion
NA
# Additional Information
NA
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
