### PR TITLE
fix GetRecords empty startposition parameter

### DIFF
--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -808,7 +808,7 @@ class Csw2(object):
             else:
                 self.parent.kvp['sortby']['order'] = 'ASC'
 
-        if 'startposition' not in self.parent.kvp:
+        if 'startposition' not in self.parent.kvp or not self.parent.kvp['startposition']:
             self.parent.kvp['startposition'] = 1
 
         # query repository

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -837,7 +837,7 @@ class Csw3(object):
             else:
                 self.parent.kvp['sortby']['order'] = 'ASC'
 
-        if 'startposition' not in self.parent.kvp:
+        if 'startposition' not in self.parent.kvp or not self.parent.kvp['startposition']:
             self.parent.kvp['startposition'] = 1
 
         if 'recordids' in self.parent.kvp and self.parent.kvp['recordids'] != '':


### PR DESCRIPTION
# Overview
This PR fixes empty GetRecords `startposition` parameter passing.

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
