### PR TITLE
Update interpreter path for python3

### DIFF
--- a/tests/gen_html.py
+++ b/tests/gen_html.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # =================================================================
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>


### PR DESCRIPTION
# Overview

Since python2 is no longer supported, the interpreter path to use python3 explicitly.

# Related Issue / Discussion

N/A

# Additional Information

Also reported by the lintian QA tool.

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
