### PR TITLE
remove encoding kw from json.loads

### DIFF
--- a/tests/functionaltests/test_suites_functional.py
+++ b/tests/functionaltests/test_suites_functional.py
@@ -216,7 +216,7 @@ def _test_xml_result(result, expected, encoding="utf-8"):
     return matches
 
 
-def _test_json_result(result, expected, encoding="utf-8"):
+def _test_json_result(result, expected):
     """Compare the JSON test results with an expected value.
 
     Parameters
@@ -233,8 +233,8 @@ def _test_json_result(result, expected, encoding="utf-8"):
 
     """
 
-    result_dict = json.loads(result, encoding=encoding)
-    expected_dict = json.loads(expected, encoding=encoding)
+    result_dict = json.loads(result)
+    expected_dict = json.loads(expected)
     return result_dict == expected_dict
 
 


### PR DESCRIPTION
The test suite fails with python 3.9, because the `encoding` parameter [was removed](https://docs.python.org/3/library/json.html#json.loads)

AFAICT, `_test_json_result` is not called with the encoding parameter anywhere.

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute this bugfix regarding json.loads for py3.9 to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
