### PR TITLE
handle OpenSearch template URLs in query string

### DIFF
--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -250,7 +250,11 @@ class Csw(object):
             self.requesttype = 'GET'
             self.request = wsgiref.util.request_uri(self.environ)
             try:
-                query_part = splitquery(self.request)[-1]
+                if '{' in self.request and '}' in self.request:
+                    LOGGER.debug('Looks like an OpenSearch URL template')
+                    query_part = self.request.split('?', 1)[-1]
+                else:
+                    query_part = splitquery(self.request)[-1]
                 self.kvp = dict(parse_qsl(query_part, keep_blank_values=True))
             except AttributeError as err:
                 LOGGER.exception('Could not parse query string')

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -250,7 +250,7 @@ class Csw(object):
             self.requesttype = 'GET'
             self.request = wsgiref.util.request_uri(self.environ)
             try:
-                if '{' in self.request and '}' in self.request:
+                if '{' in self.request or '%7D' in self.request:
                     LOGGER.debug('Looks like an OpenSearch URL template')
                     query_part = self.request.split('?', 1)[-1]
                 else:


### PR DESCRIPTION
# Overview
This PR fixes query string handling in support of OpenSearch URL templates with optional parameters specified.  Example string:

`http://localhost:8000/?mode=opensearch&service=CSW&version=2.0.2&request=GetRecords&elementsetname=full&typenames=csw:Record&resulttype=results&q={searchTerms?}&bbox={geo:box?}&time={time:start?}/{time:end?}&start={time:start?}&stop={time:end?}&startposition={startIndex?}&maxrecords={count?}&eo:cloudCover={eo:cloudCover?}&eo:instrument={eo:instrument?}&eo:orbitDirection={eo:orbitDirection?}&eo:orbitNumber={eo:orbitNumber?}&eo:parentIdentifier={eo:parentIdentifier?}&eo:platform={eo:platform?}&eo:processingLevel={eo:processingLevel?}&eo:productType={eo:productType?}&eo:sensorType={eo:sensorType?}&eo:snowCover={eo:snowCover?}&eo:spectralRange={eo:spectralRange?}`

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
