### PR TITLE
Read workers from config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,8 @@ COPY --chown=pycsw \
     requirements-dev.txt \
     ./
 
+RUN pip install -U pip
+
 RUN python3 -m pip install \
     --requirement requirements.txt \
     --requirement requirements-standalone.txt \

--- a/default-sample.cfg
+++ b/default-sample.cfg
@@ -44,7 +44,7 @@ gzip_compresslevel=9
 #domaincounts=true
 #spatial_ranking=true
 profiles=apiso
-
+#workers=2
 [manager]
 transactions=false
 allowed_ips=127.0.0.1

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -174,5 +174,9 @@ if __name__ == "__main__":
         level = config.get("server", "loglevel").upper()
     except configparser.NoOptionError:
         level = "WARNING"
+    try:
+        workers = int(config.get("server", "workers"))
+    except configparser.NoOptionError:
+        workers=args.workers
     logging.basicConfig(level=getattr(logging, level))
-    launch_pycsw(config, workers=args.workers, reload=args.reload)
+    launch_pycsw(config, workers=workers, reload=args.reload)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -24,7 +24,7 @@ pycsw's runtime configuration is defined by ``default.cfg``.  pycsw ships with a
 - **profiles**: comma delimited list of profiles to load at runtime (default is none).  See :ref:`profiles`
 - **smtp_host**: SMTP host for processing ``csw:ResponseHandler`` parameter via outgoing email requests (default is ``localhost``)
 - **spatial_ranking**: parameter that enables (``true`` or ``false``) ranking of spatial query results as per `K.J. Lanfear 2006 - A Spatial Overlay Ranking Method for a Geospatial Search of Text Objects  <http://pubs.usgs.gov/of/2006/1279/2006-1279.pdf>`_.
-
+- **workers**: set the number of workers used by the wsgi server when lunching pycsw using the provided docker/entrypoint.py. If not set, it will use 2 workers as Default.
 **[manager]**
 
 - **transactions**: whether to enable transactions (``true`` or ``false``).  Default is ``false`` (see :ref:`transactions`)


### PR DESCRIPTION
# Overview
This PR simply add the option to read the number of workers from the  pycsw configuration for an easier deployment process
# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
