### PR TITLE
Read workers from config

### DIFF
--- a/default-sample.cfg
+++ b/default-sample.cfg
@@ -44,6 +44,7 @@ gzip_compresslevel=9
 #domaincounts=true
 #spatial_ranking=true
 profiles=apiso
+#workers=2
 
 [manager]
 transactions=false

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -174,5 +174,9 @@ if __name__ == "__main__":
         level = config.get("server", "loglevel").upper()
     except configparser.NoOptionError:
         level = "WARNING"
+    try:
+        workers = int(config.get("server", "workers"))
+    except configparser.NoOptionError:
+        workers = args.workers
     logging.basicConfig(level=getattr(logging, level))
-    launch_pycsw(config, workers=args.workers, reload=args.reload)
+    launch_pycsw(config, workers=workers, reload=args.reload)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -24,6 +24,7 @@ pycsw's runtime configuration is defined by ``default.cfg``.  pycsw ships with a
 - **profiles**: comma delimited list of profiles to load at runtime (default is none).  See :ref:`profiles`
 - **smtp_host**: SMTP host for processing ``csw:ResponseHandler`` parameter via outgoing email requests (default is ``localhost``)
 - **spatial_ranking**: parameter that enables (``true`` or ``false``) ranking of spatial query results as per `K.J. Lanfear 2006 - A Spatial Overlay Ranking Method for a Geospatial Search of Text Objects  <http://pubs.usgs.gov/of/2006/1279/2006-1279.pdf>`_.
+- **workers**: set the number of workers used by the wsgi server when lunching pycsw using the provided docker/entrypoint.py. If not set, it will use 2 workers as Default.
 
 **[manager]**
 

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -250,7 +250,11 @@ class Csw(object):
             self.requesttype = 'GET'
             self.request = wsgiref.util.request_uri(self.environ)
             try:
-                query_part = splitquery(self.request)[-1]
+                if '{' in self.request or '%7D' in self.request:
+                    LOGGER.debug('Looks like an OpenSearch URL template')
+                    query_part = self.request.split('?', 1)[-1]
+                else:
+                    query_part = splitquery(self.request)[-1]
                 self.kvp = dict(parse_qsl(query_part, keep_blank_values=True))
             except AttributeError as err:
                 LOGGER.exception('Could not parse query string')
@@ -392,16 +396,8 @@ class Csw(object):
             rs_cls = getattr(rs_mod, rs_clsname)
 
             try:
-                connection_done=False
-                max_attempt=0
-                while not connection_done and max_attempt<=5:
-                    try:
-                        self.repository = rs_cls(self.context, repo_filter)
-                        LOGGER.debug('Custom repository %s loaded (%s)', rs, self.repository.dbtype)
-                        connection_done=True
-                    except:
-                        LOGGER.debug(f'Repository not loaded retry connection {max_attempt}')
-                        max_attempt=+1
+                self.repository = rs_cls(self.context, repo_filter)
+                LOGGER.debug('Custom repository %s loaded (%s)', rs, self.repository.dbtype)
             except Exception as err:
                 msg = 'Could not load custom repository %s: %s' % (rs, err)
                 LOGGER.exception(msg)
@@ -415,23 +411,15 @@ class Csw(object):
             from pycsw.core import repository
             try:
                 LOGGER.info('Loading default repository')
-                connection_done=False
-                max_attempt=0
-                while not connection_done and max_attempt<=5:
-                    try:
-                        self.repository = repository.Repository(
-                            self.config.get('repository', 'database'),
-                            self.context,
-                            self.environ.get('local.app_root', None),
-                            self.config.get('repository', 'table'),
-                            repo_filter
-                        )
-                        LOGGER.debug(
-                            'Repository loaded (local): %s.' % self.repository.dbtype)
-                        connection_done=True
-                    except:
-                        LOGGER.debug(f'Repository not loaded retry connection {max_attempt}')
-                        max_attempt=+1
+                self.repository = repository.Repository(
+                    self.config.get('repository', 'database'),
+                    self.context,
+                    self.environ.get('local.app_root', None),
+                    self.config.get('repository', 'table'),
+                    repo_filter
+                )
+                LOGGER.debug(
+                    'Repository loaded (local): %s.' % self.repository.dbtype)
             except Exception as err:
                 msg = 'Could not load repository (local): %s' % err
                 LOGGER.exception(msg)


### PR DESCRIPTION
# Overview
This PR adds the option to read the number of workers from the pycsw configuration for an easier deployment process.

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
