### PR TITLE
Max attempt retry connection to cold db

### DIFF
--- a/default-sample.cfg
+++ b/default-sample.cfg
@@ -45,7 +45,6 @@ gzip_compresslevel=9
 #spatial_ranking=true
 profiles=apiso
 #workers=2
-#max_db_conn_retry_attempt=5
 
 [manager]
 transactions=false
@@ -86,6 +85,7 @@ database=sqlite:////var/www/pycsw/tests/functionaltests/suites/cite/data/cite.db
 #mappings=path/to/mappings.py
 table=records
 #filter=type = 'http://purl.org/dc/dcmitype/Dataset'
+#max_retries=5
 
 [metadata:inspire]
 enabled=true

--- a/default-sample.cfg
+++ b/default-sample.cfg
@@ -45,6 +45,7 @@ gzip_compresslevel=9
 #spatial_ranking=true
 profiles=apiso
 #workers=2
+#max_db_conn_retry_attempt=5
 
 [manager]
 transactions=false

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -25,7 +25,6 @@ pycsw's runtime configuration is defined by ``default.cfg``.  pycsw ships with a
 - **smtp_host**: SMTP host for processing ``csw:ResponseHandler`` parameter via outgoing email requests (default is ``localhost``)
 - **spatial_ranking**: parameter that enables (``true`` or ``false``) ranking of spatial query results as per `K.J. Lanfear 2006 - A Spatial Overlay Ranking Method for a Geospatial Search of Text Objects  <http://pubs.usgs.gov/of/2006/1279/2006-1279.pdf>`_.
 - **workers**: set the number of workers used by the wsgi server when lunching pycsw using the provided docker/entrypoint.py. If not set, it will use 2 workers as Default.
-- **max_db_conn_retry_attempt**: max number of retry attempts when connecting to records-repository database
 
 **[manager]**
 
@@ -65,6 +64,7 @@ pycsw's runtime configuration is defined by ``default.cfg``.  pycsw ships with a
 - **mappings**: custom repository mappings (see :ref:`custom_repository`)
 - **source**: the source of this repository only if not local (e.g. :ref:`geonode`, :ref:`odc`).  Supported values are ``geonode``, ``odc``
 - **filter**: server side database filter to apply as mask to all CSW requests (see :ref:`repofilters`)
+- **max_retries**: max number of retry attempts when connecting to records-repository database
 
 .. note::
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -25,6 +25,7 @@ pycsw's runtime configuration is defined by ``default.cfg``.  pycsw ships with a
 - **smtp_host**: SMTP host for processing ``csw:ResponseHandler`` parameter via outgoing email requests (default is ``localhost``)
 - **spatial_ranking**: parameter that enables (``true`` or ``false``) ranking of spatial query results as per `K.J. Lanfear 2006 - A Spatial Overlay Ranking Method for a Geospatial Search of Text Objects  <http://pubs.usgs.gov/of/2006/1279/2006-1279.pdf>`_.
 - **workers**: set the number of workers used by the wsgi server when lunching pycsw using the provided docker/entrypoint.py. If not set, it will use 2 workers as Default.
+- **max_db_conn_retry_attempt**: max number of retry attempts when connecting to records-repository database
 
 **[manager]**
 

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -211,7 +211,7 @@ class Csw(object):
 
         # load user-defined max attempt to retry db connection
         try:
-            self.max_db_conn_retry_attempt = int(config.get("server", "max_db_conn_retry_attempt"))
+            self.max_db_conn_retry_attempt = int(self.config.get("server", "max_db_conn_retry_attempt"))
         except configparser.NoOptionError:
             self.max_db_conn_retry_attempt = 5
 

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -211,9 +211,9 @@ class Csw(object):
 
         # load user-defined max attempt to retry db connection
         try:
-            self.max_db_conn_retry_attempt = int(self.config.get("server", "max_db_conn_retry_attempt"))
+            self.max_retries = int(self.config.get("repository", "max_retries"))
         except configparser.NoOptionError:
-            self.max_db_conn_retry_attempt = 5
+            self.max_retries = 5
 
         # load outputschemas
         LOGGER.info('Loading outputschemas')
@@ -419,7 +419,7 @@ class Csw(object):
                 LOGGER.info('Loading default repository')
                 connection_done = False
                 max_attempt = 0
-                while not connection_done and max_attempt <= self.max_db_conn_retry_attempt:
+                while not connection_done and max_attempt <= self.max_retries:
                     self.repository = repository.Repository(
                         self.config.get('repository', 'database'),
                         self.context,

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -250,7 +250,11 @@ class Csw(object):
             self.requesttype = 'GET'
             self.request = wsgiref.util.request_uri(self.environ)
             try:
-                query_part = splitquery(self.request)[-1]
+                if '{' in self.request or '%7D' in self.request:
+                    LOGGER.debug('Looks like an OpenSearch URL template')
+                    query_part = self.request.split('?', 1)[-1]
+                else:
+                    query_part = splitquery(self.request)[-1]
                 self.kvp = dict(parse_qsl(query_part, keep_blank_values=True))
             except AttributeError as err:
                 LOGGER.exception('Could not parse query string')
@@ -392,16 +396,8 @@ class Csw(object):
             rs_cls = getattr(rs_mod, rs_clsname)
 
             try:
-                connection_done=False
-                max_attempt=0
-                while not connection_done and max_attempt<=5:
-                    try:
-                        self.repository = rs_cls(self.context, repo_filter)
-                        LOGGER.debug('Custom repository %s loaded (%s)', rs, self.repository.dbtype)
-                        connection_done=True
-                    except:
-                        LOGGER.debug(f'Repository not loaded retry connection {max_attempt}')
-                        max_attempt=+1
+                self.repository = rs_cls(self.context, repo_filter)
+                LOGGER.debug('Custom repository %s loaded (%s)', rs, self.repository.dbtype)
             except Exception as err:
                 msg = 'Could not load custom repository %s: %s' % (rs, err)
                 LOGGER.exception(msg)
@@ -415,23 +411,15 @@ class Csw(object):
             from pycsw.core import repository
             try:
                 LOGGER.info('Loading default repository')
-                connection_done=False
-                max_attempt=0
-                while not connection_done and max_attempt<=5:
-                    try:
-                        self.repository = repository.Repository(
-                            self.config.get('repository', 'database'),
-                            self.context,
-                            self.environ.get('local.app_root', None),
-                            self.config.get('repository', 'table'),
-                            repo_filter
-                        )
-                        LOGGER.debug(
-                            'Repository loaded (local): %s.' % self.repository.dbtype)
-                        connection_done=True
-                    except:
-                        LOGGER.debug(f'Repository not loaded retry connection {max_attempt}')
-                        max_attempt=+1
+                self.repository = repository.Repository(
+                    self.config.get('repository', 'database'),
+                    self.context,
+                    self.environ.get('local.app_root', None),
+                    self.config.get('repository', 'table'),
+                    repo_filter
+                )
+                LOGGER.debug(
+                    'Repository loaded (local): %s.' % self.repository.dbtype)
             except Exception as err:
                 msg = 'Could not load repository (local): %s' % err
                 LOGGER.exception(msg)


### PR DESCRIPTION
# Overview
This PR attempts to mitigate a connection issues which can arise when the service attempts to connecting to a 'cold-db' (e.g.: service in idle state in a docker swarm setting). The retrty loop uses a new configure option `max_db_conn_retry_attempt` to retry the connection until  such value is reached - default value for `max_db_conn_retry_attempt` is set to `5`.

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
