### PR TITLE
Handle random db disconnect

### DIFF
--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -71,7 +71,7 @@ class Repository(object):
         '''
         if url not in clazz._engines:
             LOGGER.info('creating new engine: %s', url)
-            engine = create_engine('%s' % url, echo=False)
+            engine = create_engine('%s' % url, echo=False, pool_pre_ping=True)
 
             # load SQLite query bindings
             # This can be directly bound via events


### PR DESCRIPTION

# Overview

while testing my endpoints I found some random errors due to a DB disconnect issue,  -  reading the logs:  https://gist.github.com/epifanio/9970069e38457db1fa9ad248ec442ffa    the sqlalchemy docs have some hints on how to deal with such errors. I found that adding  `pool_pre_ping=True` in  the  `sqlalchemy.create_engine()` call in https://github.com/geopython/pycsw/blob/master/pycsw/core/repository.py#L74  - seems to help -  the random error is gone (so far)

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
