### PR TITLE
Fix updated records with garbled XML

### DIFF
--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -320,6 +320,10 @@ class Repository(object):
             anytext = getattr(self.dataset,
             self.context.md_core_model['mappings']['pycsw:AnyText'])
 
+            if isinstance(record.xml, bytes):
+                LOGGER.debug('Decoding bytes to unicode')
+                record.xml = record.xml.decode()
+
         if recprops is None and constraint is None:  # full update
             LOGGER.debug('full update')
             update_dict = dict([(getattr(self.dataset, key),


### PR DESCRIPTION


# Overview

Updating an already-existing XML record in our postgresql repository via PyCSW caused the `xml` attribute to be set to a garbled hex string.

Similar to #567, which was fixed for *inserted* records,
it now seems that *updated* records have their `xml` column filled
with garbage (hex-encoded binary blobs)

This fixes the issue with the same fix as the `insert` handler fix in e25721159966f155d81d3552d195dbf405f09ce2.

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute this bugfix to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
