### PR TITLE
Creates a timeout configuration for gunicorn

### DIFF
--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -101,6 +101,7 @@ def launch_pycsw(pycsw_config, workers=2, reload=False):
         "--access-logfile=-",
         "--error-logfile=-",
         "--workers={}".format(workers),
+        "--timeout={}".format(pycsw_config.get("manager", "timeout")),
         "pycsw.wsgi_flask:APP",
 
     ]

--- a/docker/pycsw.cfg
+++ b/docker/pycsw.cfg
@@ -51,6 +51,7 @@ profiles=apiso
 transactions=false
 allowed_ips=127.0.0.1
 #csw_harvest_pagesize=10
+timeout=30
 
 [metadata:main]
 identification_title=pycsw Geospatial Catalogue


### PR DESCRIPTION
# Overview
Although it is possible to specify Gunicorn's worker timeout, it is not easily passed to the application via configuration file.

# Related Issue / Discussion
#698 

# Additional Information
I have just inserted the Gunicorn's default value in pycsw.cfg and called it in entrypoint.py.

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute gunicorn's timeout configuration to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
