### PR TITLE
safeguard timeout

### DIFF
--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -95,13 +95,18 @@ def launch_pycsw(pycsw_config, workers=2, reload=False):
     # https://github.com/benoitc/gunicorn/issues/1477
     #
 
+    try:
+        timeout = pycsw_config.get("server", "timeout")
+    except configparser.NoOptionError:
+        timeout = 30
+
     args = ["--reload", "--reload-engine=poll"] if reload else []
     execution_args = ["gunicorn"] + args + [
         "--bind=0.0.0.0:8000",
         "--access-logfile=-",
         "--error-logfile=-",
         "--workers={}".format(workers),
-        "--timeout={}".format(pycsw_config.get("server", "timeout")),
+        "--timeout={}".format(timeout),
         "pycsw.wsgi_flask:APP",
 
     ]


### PR DESCRIPTION
# Overview
Safeguards timeout for configs that do not server `server.timeout` as a fix to #699 
# Related Issue / Discussion
#699
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
