### PR TITLE
add geometry to queryables

### DIFF
--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -211,7 +211,11 @@ class Repository(object):
             'VARCHAR': 'string'
         }
 
-        properties = {}
+        properties = {
+            'geometry' : {
+                '$ref' : 'https://geojson.org/schema/Polygon.json'
+            }
+        }
 
         for i in self.dataset.__table__.columns:
             if i.name in ['anytext', 'metadata', 'metadata_type', 'xml']:

--- a/tests/unittests/test_oarec.py
+++ b/tests/unittests/test_oarec.py
@@ -82,7 +82,10 @@ def test_queryables(api):
     assert content['$id'] == 'http://localhost/pycsw/oarec/collections/metadata:main/queryables'  # noqa
     assert content['$schema'] == 'http://json-schema.org/draft/2019-09/schema'
 
-    assert len(content['properties']) == 59
+    assert len(content['properties']) == 60
+
+    assert 'geometry' in content['properties']
+    assert content['properties']['geometry']['$ref'] == 'https://geojson.org/schema/Polygon.json'  # noqa
 
 
 def test_items(api):


### PR DESCRIPTION
# Overview
Adds a default polygon geometry to OARec `queryables`
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
