### PR TITLE
Exception logging improvements

### DIFF
--- a/pycsw/core/admin.py
+++ b/pycsw/core/admin.py
@@ -412,7 +412,7 @@ def export_records(context, database, table, xml_dirpath):
             os.makedirs(dirpath)
         except OSError as err:
             LOGGER.exception('Could not create directory')
-            raise RuntimeError('Could not create %s %s' % (dirpath, err))
+            raise RuntimeError('Could not create %s %s' % (dirpath, err)) from err
 
     for record in records.all():
         identifier = \
@@ -571,7 +571,7 @@ def post_xml(url, xml, timeout=30):
             return http_post(url=url, request=f.read(), timeout=timeout)
     except Exception as err:
         LOGGER.exception('HTTP XML POST error')
-        raise RuntimeError(err)
+        raise RuntimeError(err) from err
 
 
 def get_sysprof():
@@ -636,7 +636,7 @@ def validate_xml(xml, xsd):
         return 'Valid'
     except Exception as err:
         LOGGER.exception('Invalid XML')
-        raise RuntimeError('ERROR: %s' % str(err))
+        raise RuntimeError('ERROR: %s' % str(err)) from err
 
 
 def delete_records(context, database, table):
@@ -699,7 +699,7 @@ def cli_setup_db(ctx, config, verbosity):
         )
     except Exception as err:
         msg = f'ERROR: Database tables already exist: {err}'
-        raise click.ClickException(msg)
+        raise click.ClickException(msg) from err
 
 
 @click.command('load-records')

--- a/pycsw/core/admin.py
+++ b/pycsw/core/admin.py
@@ -353,7 +353,7 @@ def load_records(context, database, table, xml_dirpath, recursive=False, force_u
         try:
             exml = etree.parse(recfile, context.parser)
         except etree.XMLSyntaxError as err:
-            LOGGER.error('XML document "%s" is not well-formed', recfile)
+            LOGGER.error('XML document "%s" is not well-formed', recfile, exc_info=True)
             continue
         except Exception as err:
             LOGGER.exception('XML document "%s" is not well-formed', recfile)
@@ -384,9 +384,9 @@ def load_records(context, database, table, xml_dirpath, recursive=False, force_u
                     if isinstance(err, DBAPIError) and err.args:
                         # Pull a decent database error message and not the full SQL that was run
                         # since INSERT SQL statements are rather large.
-                        LOGGER.error('ERROR: %s not inserted: %s', recfile, err.args[0])
+                        LOGGER.error('ERROR: %s not inserted: %s', recfile, err.args[0], exc_info=True)
                     else:
-                        LOGGER.error('ERROR: %s not inserted: %s', recfile, err)
+                        LOGGER.error('ERROR: %s not inserted: %s', recfile, err, exc_info=True)
 
     return tuple(loaded_files)
 

--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1649,4 +1649,4 @@ def bbox_from_polygons(bboxs):
         bstr = ",".join(["{0:.2f}".format(b) for b in multi_pol.bounds])
         return util.bbox2wktpolygon(bstr)
     except Exception as err:
-        raise RuntimeError('Cannot aggregate polygons: %s' % str(err))
+        raise RuntimeError('Cannot aggregate polygons: %s' % str(err)) from err

--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -160,7 +160,7 @@ class Repository(object):
                 temp_dbtype = 'postgresql+postgis+native'
                 LOGGER.debug('PostgreSQL+PostGIS+Native detected')
             except Exception as err:
-                LOGGER.exception('PostgreSQL+PostGIS+Native not picked up: %s')
+                LOGGER.exception('PostgreSQL+PostGIS+Native not picked up: %s', table_name)
 
             # check if a native PostgreSQL FTS GIN index exists
             result = self.session.execute("select relname from pg_class where relname='fts_gin_idx'").scalar()

--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -368,7 +368,7 @@ class Repository(object):
                 self.session.rollback()
                 msg = 'Cannot commit to repository'
                 LOGGER.exception(msg)
-                raise RuntimeError(msg)
+                raise RuntimeError(msg) from err
         else:  # update based on record properties
             LOGGER.debug('property based update')
             try:
@@ -403,7 +403,7 @@ class Repository(object):
                 self.session.rollback()
                 msg = 'Cannot commit to repository'
                 LOGGER.exception(msg)
-                raise RuntimeError(msg)
+                raise RuntimeError(msg) from err
 
     def delete(self, constraint):
         ''' Delete a record from the repository '''
@@ -433,7 +433,7 @@ class Repository(object):
             self.session.rollback()
             msg = 'Cannot commit to repository'
             LOGGER.exception(msg)
-            raise RuntimeError(msg)
+            raise RuntimeError(msg) from err
 
         return rows
 
@@ -541,8 +541,8 @@ def update_xpath(nsmap, xml, recprop):
                 if node1.text != recprop['value']:  # values differ, update
                     node1.text = recprop['value']
     except Exception as err:
-        raise RuntimeError('ERROR: %s' % str(err))
         LOGGER.warning('update_xpath error', exc_info=True)
+        raise RuntimeError('ERROR: %s' % str(err)) from err
 
     return etree.tostring(xml)
 

--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -541,8 +541,8 @@ def update_xpath(nsmap, xml, recprop):
                 if node1.text != recprop['value']:  # values differ, update
                     node1.text = recprop['value']
     except Exception as err:
-        LOGGER.warning(err)
         raise RuntimeError('ERROR: %s' % str(err))
+        LOGGER.warning('update_xpath error', exc_info=True)
 
     return etree.tostring(xml)
 
@@ -581,7 +581,7 @@ def get_spatial_overlay_rank(target_geometry, query_geometry):
                 LOGGER.debug('Spatial Rank: %s', str(((X/Q)**kq)*((X/T)**kt)))
                 return str(((X/Q)**kq)*((X/T)**kt))
         except Exception as err:
-            LOGGER.warning('Cannot derive spatial overlay ranking %s', err)
+            LOGGER.warning('Cannot derive spatial overlay ranking', exc_info=True)
             return '0'
     return '0'
 

--- a/pycsw/core/util.py
+++ b/pycsw/core/util.py
@@ -126,7 +126,7 @@ def get_version_integer(version):
         else:
             result = -1
     except AttributeError as err:
-        raise RuntimeError('%s' % str(err))
+        raise RuntimeError('%s' % str(err)) from err
     return result
 
 

--- a/pycsw/ogc/fes/fes1.py
+++ b/pycsw/ogc/fes/fes1.py
@@ -123,7 +123,7 @@ def parse(element, queryables, dbtype, nsmap, orm='sqlalchemy', language='englis
                 LOGGER.debug('Testing existence of ogc:PropertyName')
                 pname = queryables[elem.find(util.nspath_eval('ogc:Function/ogc:PropertyName', nsmap)).text]['dbcol']
             except Exception as err:
-                raise RuntimeError('Invalid PropertyName: %s.  %s' % (elem.find(util.nspath_eval('ogc:Function/ogc:PropertyName', nsmap)).text, str(err)))
+                raise RuntimeError('Invalid PropertyName: %s.  %s' % (elem.find(util.nspath_eval('ogc:Function/ogc:PropertyName', nsmap)).text, str(err))) from err
 
         else:
             try:
@@ -133,7 +133,7 @@ def parse(element, queryables, dbtype, nsmap, orm='sqlalchemy', language='englis
             except Exception as err:
                 raise RuntimeError('Invalid PropertyName: %s.  %s' %
                                    (elem.find(util.nspath_eval('ogc:PropertyName',
-                                   nsmap)).text, str(err)))
+                                   nsmap)).text, str(err))) from err
 
         if (elem.tag != util.nspath_eval('ogc:PropertyIsBetween', nsmap)):
             if elem.tag in [util.nspath_eval('ogc:%s' % n, nsmap) for n in

--- a/pycsw/ogc/fes/fes2.py
+++ b/pycsw/ogc/fes/fes2.py
@@ -142,7 +142,7 @@ def parse(element, queryables, dbtype, nsmap, orm='sqlalchemy', language='englis
                 LOGGER.debug('Testing existence of fes20:ValueReference')
                 pname = queryables[elem.find(util.nspath_eval('fes20:Function/fes20:ValueReference', nsmap)).text]['dbcol']
             except Exception as err:
-                raise RuntimeError('Invalid PropertyName: %s.  %s' % (elem.find(util.nspath_eval('fes20:Function/fes20:ValueReference', nsmap)).text, str(err)))
+                raise RuntimeError('Invalid PropertyName: %s.  %s' % (elem.find(util.nspath_eval('fes20:Function/fes20:ValueReference', nsmap)).text, str(err))) from err
 
         else:
             try:
@@ -152,7 +152,7 @@ def parse(element, queryables, dbtype, nsmap, orm='sqlalchemy', language='englis
             except Exception as err:
                 raise RuntimeError('Invalid PropertyName: %s.  %s' %
                                    (elem.find(util.nspath_eval('fes20:ValueReference',
-                                   nsmap)).text, str(err)))
+                                   nsmap)).text, str(err))) from err
 
         if (elem.tag != util.nspath_eval('fes20:PropertyIsBetween', nsmap)):
             if elem.tag in [util.nspath_eval('fes20:%s' % n, nsmap) for n in


### PR DESCRIPTION
1. Bug: fix missing log argument for postgresql repository setup

2. logging: add exception info to error/warn messages.
Error tracing systems like Sentry produce much more useful events with exception contexts. While these are automatically associated for `logger.exception()` calls, that doesn't happen for other log levels. Change: Where a `.warn()`/`.error()` log call is associated with an Exception object, pass it to the logger.
Implications: in some log configurations this will log tracebacks more often

3. Use `raise ... from ...` syntax when re-raising exceptions, so cause is propagated. Again, helps error tracing.

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute code to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
