### PR TITLE
OARec multiple query terms

### DIFF
--- a/docs/oarec-support.rst
+++ b/docs/oarec-support.rst
@@ -39,6 +39,8 @@ JSON and HTML output formats are both supported via the ``f`` parameter.
   http://localhost:8000/collections/metadata:main/items
   # collection query, full text search
   http://localhost:8000/collections/metadata:main/items?q=lorem
+  # collection query, full text search (multiple terms result in an exclusive (AND) search
+  http://localhost:8000/collections/metadata:main/items?q=lorem dolor
   # collection query, spatial query
   http://localhost:8000/collections/metadata:main/items?bbox=-142,42,-52,84
   # collection query, temporal query

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -476,7 +476,7 @@ class API:
 
             if k not in reserved_query_params:
                 if k == 'anytext':
-                    query_args.append(f'{k} LIKE "%{v}%"')
+                    query_args.append(build_anytext(k, v))
                 elif k == 'bbox':
                     query_args.append(f'BBOX(geometry, {v})')
                 elif k == 'datetime':
@@ -489,7 +489,7 @@ class API:
                         if end != '..':
                             query_args.append(f'time_end <= "{end}"')
                 elif k == 'q':
-                    query_args.append(f'anytext LIKE "%{v}%"')
+                    query_args.append(build_anytext('anytext', v))
                 else:
                     query_args.append(f'{k} = "{v}"')
 
@@ -764,3 +764,24 @@ def record2json(record, stac_item=False):
         }
 
     return record_dict
+
+def build_anytext(name, value):
+    """
+    deconstructs free-text search into CQL predicate
+
+    :param name: property name
+    :param name: property value
+
+    :returns: string of CQL predicate
+    """
+
+    predicates = []
+    tokens = value.split()
+
+    if len(tokens) == 1:  # single term
+        return f'{name} LIKE "%{value}%"'
+
+    for token in tokens:
+        predicates.append(f'{name} LIKE "%{token}%"')
+
+    return ' AND '.join(predicates)

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -767,12 +767,12 @@ def record2json(record, stac_item=False):
 
 def build_anytext(name, value):
     """
-    deconstructs free-text search into CQL predicate
+    deconstructs free-text search into CQL predicate(s)
 
     :param name: property name
     :param name: property value
 
-    :returns: string of CQL predicate
+    :returns: string of CQL predicate(s)
     """
 
     predicates = []

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -784,4 +784,4 @@ def build_anytext(name, value):
     for token in tokens:
         predicates.append(f'{name} LIKE "%{token}%"')
 
-    return ' AND '.join(predicates)
+    return f"({' AND '.join(predicates)})"

--- a/pycsw/wsgi_flask.py
+++ b/pycsw/wsgi_flask.py
@@ -65,10 +65,7 @@ def get_response(result: tuple):
 
     headers, status, content = result
 
-    print("CONTENT", content)
-    print("CONTENT", len(content))
     response = make_response(content, status)
-    print(response)
 
     if headers:
         response.headers = headers

--- a/tests/unittests/test_oarec.py
+++ b/tests/unittests/test_oarec.py
@@ -104,6 +104,12 @@ def test_items(api):
     assert content['numberReturned'] == 5
     assert len(content['features']) == content['numberReturned']
 
+    params = {'q': 'Lorem dolor'}
+    content = json.loads(api.items({}, params)[2])
+    assert content['numberMatched'] == 1
+    assert content['numberReturned'] == 1
+    assert len(content['features']) == content['numberReturned']
+
     params = {'bbox': '-50,0,50,80'}
     content = json.loads(api.items({}, params)[2])
     assert content['numberMatched'] == 3

--- a/tests/unittests/test_oarec.py
+++ b/tests/unittests/test_oarec.py
@@ -57,7 +57,7 @@ def test_openapi(api):
 def test_conformance(api):
     content = json.loads(api.conformance({}, {})[2])
 
-    assert len(content['conformsTo']) == 8
+    assert len(content['conformsTo']) == 9
 
 
 def test_collections(api):
@@ -89,7 +89,7 @@ def test_queryables(api):
 
 
 def test_items(api):
-    content = json.loads(api.items({}, {})[2])
+    content = json.loads(api.items({}, None, {})[2])
 
     assert content['type'] == 'FeatureCollection'
     assert len(content['links']) == 4
@@ -99,49 +99,49 @@ def test_items(api):
     assert len(content['features']) == content['numberReturned']
 
     params = {'q': 'Lorem'}
-    content = json.loads(api.items({}, params)[2])
+    content = json.loads(api.items({}, None, params)[2])
     assert content['numberMatched'] == 5
     assert content['numberReturned'] == 5
     assert len(content['features']) == content['numberReturned']
 
     params = {'q': 'Lorem dolor'}
-    content = json.loads(api.items({}, params)[2])
+    content = json.loads(api.items({}, None, params)[2])
     assert content['numberMatched'] == 1
     assert content['numberReturned'] == 1
     assert len(content['features']) == content['numberReturned']
 
     params = {'bbox': '-50,0,50,80'}
-    content = json.loads(api.items({}, params)[2])
+    content = json.loads(api.items({}, None, params)[2])
     assert content['numberMatched'] == 3
     assert content['numberReturned'] == 3
     assert len(content['features']) == content['numberReturned']
 
     params = {'bbox': '-50,0,50,80', 'q': 'Lorem'}
-    content = json.loads(api.items({}, params)[2])
+    content = json.loads(api.items({}, None, params)[2])
     assert content['numberMatched'] == 1
     assert content['numberReturned'] == 1
     assert len(content['features']) == content['numberReturned']
 
     params = {'filter': 'title LIKE "%%Lorem%%"'}
-    content = json.loads(api.items({}, params)[2])
+    content = json.loads(api.items({}, None, params)[2])
     assert content['numberMatched'] == 2
     assert content['numberReturned'] == 2
     assert len(content['features']) == content['numberReturned']
 
     params = {'filter': 'title LIKE "%%Lorem%%"', 'q': 'iPsUm'}
-    content = json.loads(api.items({}, params)[2])
+    content = json.loads(api.items({}, None, params)[2])
     assert content['numberMatched'] == 2
     assert content['numberReturned'] == 2
     assert len(content['features']) == content['numberReturned']
 
     params = {'limit': 4}
-    content = json.loads(api.items({}, params)[2])
+    content = json.loads(api.items({}, None, params)[2])
     assert content['numberMatched'] == 12
     assert content['numberReturned'] == 4
     assert len(content['features']) == content['numberReturned']
 
     params = {'limit': 4, 'startindex': 10}
-    content = json.loads(api.items({}, params)[2])
+    content = json.loads(api.items({}, None, params)[2])
     assert content['numberMatched'] == 12
     assert content['numberReturned'] == 2
     assert len(content['features']) == content['numberReturned']


### PR DESCRIPTION
# Overview
This PR updates OARec `q=` support to produce exclusive (AND'ed) CQL predicates when `q=` contains multiple terms.

In addition, `tests/functionaltests/suites/cite/data/cite.db` has been reverted given an erroneous commit in 9e1fc745ab5d49e35154bc6f91d2442483603aef

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
