### PR TITLE
link to GeoJSON Polygon geometry for queryables

### DIFF
--- a/pycsw/ogc/api/templates/queryables.html
+++ b/pycsw/ogc/api/templates/queryables.html
@@ -23,6 +23,11 @@
     </thead>
     <tbody>
       {% for qname, qinfo in data['properties'].items() %}
+      {% if qname == 'geometry' %}
+      <tr>
+        <td colspan="2"><a href="{{ qinfo['$ref'] }}">{{ qname }}</a></td>
+      </tr>
+      {% else %}
       <tr>
         <td>{{ qname }}</td>
         <td>
@@ -36,6 +41,7 @@
           {% endif %}
         </td>
       </tr>
+      {% endif %}
       {% endfor %}
     </tbody>
   </table>


### PR DESCRIPTION
# Overview
Links to GeoJSON Polygon definition when rendering collection queryables in HTML.
# Related Issue / Discussion

# Additional Information
cc @kalxas 
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
