### PR TITLE
OARec: change items startindex to offset

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -85,7 +85,7 @@ Paging
 ^^^^^^
 
 - limit
-- startindex
+- offset
 
 CSW Support
 -----------

--- a/docs/oarec-support.rst
+++ b/docs/oarec-support.rst
@@ -56,11 +56,11 @@ JSON and HTML output formats are both supported via the ``f`` parameter.
   # collection query, limiting results
   http://localhost:8000/collections/metadata:main/items?limit=1
   # collection query, paging
-  http://localhost:8000/collections/metadata:main/items?limit=10&startindex=10
+  http://localhost:8000/collections/metadata:main/items?limit=10&offset=10
   # collection query, paging and sorting (default ascending)
-  http://localhost:8000/collections/metadata:main/items?limit=10&startindex=10&sortby=title
+  http://localhost:8000/collections/metadata:main/items?limit=10&offset=10&sortby=title
   # collection query, paging and sorting (descending)
-  http://localhost:8000/collections/metadata:main/items?limit=10&startindex=10&sortby=-title
+  http://localhost:8000/collections/metadata:main/items?limit=10&offset=10&sortby=-title
   # collection query as CQL JSON (HTTP POST), as curl request
   curl http://localhost:8000/collections/metadata:main/items --request POST -H "Content-Type: application/json" --data '{ "eq": [{ "property": "title" }, "Lorem ipsum"]}'
   # collection query as CQL JSON (HTTP POST), limiting results, as curl request

--- a/docs/stac.rst
+++ b/docs/stac.rst
@@ -53,11 +53,11 @@ JSON and HTML output formats are both supported via the ``f`` parameter.
   # collection query, limiting results
   http://localhost:8000/search?limit=1
   # collection query, paging
-  http://localhost:8000/search?limit=10&startindex=10
+  http://localhost:8000/search?limit=10&offset=10
   # collection query, paging and sorting (default ascending)
-  http://localhost:8000/search?limit=10&startindex=10&sortby=title
+  http://localhost:8000/search?limit=10&offset=10&sortby=title
   # collection query, paging and sorting (descending)
-  http://localhost:8000/search?limit=10&startindex=10&sortby=-title
+  http://localhost:8000/search?limit=10&offset=10&sortby=-title
   # collection query as JSON (HTTP POST), as curl request
   curl http://localhost:8000/search --request POST -H "Content-Type: application/json" --data '{"bbox": [-180, -90, 180, 90], "datetime": "2006-03-26"}'
   # collection query as JSON (HTTP POST), as curl request, with sorting (default ascending) 

--- a/pycsw/ogc/api/oapi.py
+++ b/pycsw/ogc/api/oapi.py
@@ -73,10 +73,10 @@ def gen_oapi(config, oapi_filepath):
         'style': 'form',
         'explode': False
     }
-    oapi['components']['parameters']['startindex'] = {
-        'name': 'startindex',
+    oapi['components']['parameters']['offset'] = {
+        'name': 'offset',
         'in': 'query',
-        'description': 'The optional startindex parameter indicates the index within the result set from which the server shall begin presenting results in the response document.  The first element has an index of 0 (default).',  # noqa
+        'description': 'The optional offset parameter indicates the index within the result set from which the server shall begin presenting results in the response document.  The first element has an index of 0 (default).',  # noqa
         'required': False,
         'schema': {
             'type': 'integer',
@@ -226,7 +226,7 @@ def gen_oapi(config, oapi_filepath):
                 {'$ref': '#/components/parameters/sortby'},
                 {'$ref': '#/components/parameters/filter'},
                 {'$ref': '#/components/parameters/f'},
-                {'$ref': '#/components/parameters/startindex'}
+                {'$ref': '#/components/parameters/offset'}
             ],
             'responses': {
                 '200': {

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -491,7 +491,7 @@ class API:
             'filter',
             'limit',
             'sortby',
-            'startindex'
+            'offset'
         ]
 
         response = {
@@ -636,12 +636,12 @@ class API:
         else:
             limit = self.maxrecords
 
-        startindex = int(args.get('startindex', 0))
+        offset = int(args.get('offset', 0))
 
         LOGGER.debug(f'Query: {query}')
         LOGGER.debug('Querying repository')
         count = query.count()
-        records = query.limit(limit).offset(startindex).all()
+        records = query.limit(limit).offset(offset).all()
 
         returned = len(records)
 
@@ -689,10 +689,10 @@ class API:
             'hreflang': self.config['server']['language']
         }])
 
-        if startindex > 0:
-            link_args.pop('startindex', None)
+        if offset > 0:
+            link_args.pop('offset', None)
 
-            prev = max(0, startindex - limit)
+            prev = max(0, offset - limit)
 
             url_ = f"{self.config['server']['url']}/{fragment}?{urlencode(link_args)}"
 
@@ -701,14 +701,14 @@ class API:
                     'type': 'application/geo+json',
                     'rel': 'prev',
                     'title': 'items (prev)',
-                    'href': f"{bind_url(url_)}startindex={prev}",
+                    'href': f"{bind_url(url_)}offset={prev}",
                     'hreflang': self.config['server']['language']
                 })
 
-        if (startindex + returned) < count:
-            link_args.pop('startindex', None)
+        if (offset + returned) < count:
+            link_args.pop('offset', None)
 
-            next_ = startindex + returned
+            next_ = offset + returned
 
             url_ = f"{self.config['server']['url']}/{fragment}?{urlencode(link_args)}"
 
@@ -716,7 +716,7 @@ class API:
                 'rel': 'next',
                 'type': 'application/geo+json',
                 'title': 'items (next)',
-                'href': f"{bind_url(url_)}startindex={next_}",
+                'href': f"{bind_url(url_)}offset={next_}",
                 'hreflang': self.config['server']['language']
             })
 

--- a/tests/unittests/test_oarec.py
+++ b/tests/unittests/test_oarec.py
@@ -145,7 +145,7 @@ def test_items(api):
     assert content['numberReturned'] == 4
     assert len(content['features']) == content['numberReturned']
 
-    params = {'limit': 4, 'startindex': 10}
+    params = {'limit': 4, 'offset': 10}
     content = json.loads(api.items({}, None, params)[2])
     assert content['numberMatched'] == 12
     assert content['numberReturned'] == 2

--- a/tests/unittests/test_oarec_virtual_collections.py
+++ b/tests/unittests/test_oarec_virtual_collections.py
@@ -148,7 +148,7 @@ def test_items(api):
     assert content['numberReturned'] == 4
     assert len(content['features']) == content['numberReturned']
 
-    params = {'limit': 4, 'startindex': 10}
+    params = {'limit': 4, 'offset': 10}
     content = json.loads(api.items({}, None, params)[2])
     assert content['numberMatched'] == 12
     assert content['numberReturned'] == 2


### PR DESCRIPTION
# Overview
Updates OARec items `startindex` parameter to `offset` to align with OAFeat recommendations and usage in other tooling (pygeoapi, OWSLib, QGIS server, etc.)

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
