### PR TITLE
safeguard Werkzeug 400 behaviour for JSON POST payloads

### DIFF
--- a/pycsw/wsgi_flask.py
+++ b/pycsw/wsgi_flask.py
@@ -161,7 +161,8 @@ def items(collection='metadata:main'):
     if 'search' in request.url_rule.rule:
         stac_item = True
 
-    return get_response(api_.items(dict(request.headers), request.json, dict(request.args),
+    return get_response(api_.items(dict(request.headers),
+                        request.get_json(silent=True), dict(request.args),
                         collection, stac_item))
 
 

--- a/requirements-standalone.txt
+++ b/requirements-standalone.txt
@@ -2,4 +2,3 @@ SQLAlchemy
 Flask
 pygeofilter
 PyYAML
-Werkzeug<2.1.0


### PR DESCRIPTION
# Overview
Werkzeug 2.1.0 (used by Flask [in `requirements-standalone.txt]`) introduces [stricter HTTP POST JSON payload handling](https://github.com/pallets/werkzeug/issues/2339), which results in 400 errors, [specifically](https://werkzeug.palletsprojects.com/en/2.1.x/changes/#version-2-1-0):

> `Request.get_json()` will raise a 400 `BadRequest` error if the `Content-Type` header is not `application/json`. This makes a very common source of confusion more visible. [#2339](https://github.com/pallets/werkzeug/issues/2339)

This PR provides a workaround for this breaking change.

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
