### PR TITLE
747 allow using db view as repo table

### DIFF
--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -156,17 +156,17 @@ The following instructions set up a fully working development environment::
     docker exec \
         -ti \
         --user root \
-        pycsw-dev pip3 install -r requirements-dev.txt
+        pycsw-dev pip3 install -r pycsw/requirements-dev.txt
 
     # run tests (for example unit tests)
-    docker exec -ti pycsw-dev py.test -m unit
+    docker exec -ti pycsw-dev pytest -m unit pycsw
 
     # build docs
-    docker exec -ti pycsw-dev sh -c "cd docs && make html"
+    docker exec -ti pycsw-dev sh -c "cd pycsw/docs && make html"
 
 .. note::
 
-   Please note that the pycsw image only uses python 3.5 and that it also does
+   Please note that the pycsw image only uses python 3.8 and that it also does
    not install pycsw in editable mode. As such it is not possible to
    use ``tox``.
 

--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -127,7 +127,6 @@ class Repository(object):
         else:
             table_args = default_table_args
 
-        print(f"{table_args=}")
         self.dataset = type(
             'dataset',
             (base,),

--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -111,15 +111,29 @@ class Repository(object):
 
         schema_name, table_name = table.rpartition(".")[::2]
 
+        default_table_args = {
+            "autoload": True,
+            "schema": schema_name or None
+        }
+        column_constraints = context.md_core_model.get("column_constraints")
+
+        # Note: according to the sqlalchemy docs available here:
+        #
+        # https://docs.sqlalchemy.org/en/14/orm/declarative_tables.html#declarative-table-configuration
+        #
+        # the __table_args__ attribute can either be a tuple or a dict
+        if column_constraints is not None:
+            table_args = tuple((*column_constraints, default_table_args))
+        else:
+            table_args = default_table_args
+
+        print(f"{table_args=}")
         self.dataset = type(
             'dataset',
             (base,),
             {
                 "__tablename__": table_name,
-                "__table_args__": {
-                    "autoload": True,
-                    "schema": schema_name or None,
-                },
+                "__table_args__": table_args,
             }
         )
 

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -110,7 +110,7 @@ class API:
         if self.config.has_option('repository', 'filter'):
             repo_filter = self.config.get('repository', 'filter')
 
-        custom_mappings_path = self.config.get('repository', 'mappings')
+        custom_mappings_path = self.config.get('repository', 'mappings', None)
         if custom_mappings_path is not None:
             md_core_model = load_custom_repo_mappings(custom_mappings_path)
             if md_core_model is not None:

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -110,7 +110,7 @@ class API:
         if self.config.has_option('repository', 'filter'):
             repo_filter = self.config.get('repository', 'filter')
 
-        custom_mappings_path = self.config.get('repository', 'mappings', None)
+        custom_mappings_path = self.config.get('repository', 'mappings', fallback=None)
         if custom_mappings_path is not None:
             md_core_model = load_custom_repo_mappings(custom_mappings_path)
             if md_core_model is not None:

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -110,6 +110,30 @@ class API:
         if self.config.has_option('repository', 'filter'):
             repo_filter = self.config.get('repository', 'filter')
 
+
+        if self.config.has_option('repository', 'mappings'):
+            # override default repository mappings
+            try:
+                import imp
+                module = self.config.get('repository', 'mappings')
+                if os.sep in module:  # filepath
+                    modulename = '%s' % os.path.splitext(module)[0].replace(
+                        os.sep, '.')
+                    mappings = imp.load_source(modulename, module)
+                else:  # dotted name
+                    mappings = __import__(module, fromlist=[''])
+                LOGGER.info('Loading custom repository mappings '
+                            'from %s', module)
+                self.context.md_core_model = mappings.MD_CORE_MODEL
+                self.context.refresh_dc(mappings.MD_CORE_MODEL)
+            except Exception as err:
+                LOGGER.exception('Could not load custom mappings: %s', err)
+                self.response = self.iface.exceptionreport(
+                    'NoApplicableCode', 'service',
+                    'Could not load repository.mappings')
+
+
+
         self.orm = 'sqlalchemy'
         from pycsw.core import repository
         try:

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -184,7 +184,7 @@ class Csw(object):
         LOGGER.debug('Model: %s.', self.context.model)
 
         # load user-defined mappings if they exist
-        custom_mappings_path = self.config.get('repository', 'mappings')
+        custom_mappings_path = self.config.get('repository', 'mappings', None)
         if custom_mappings_path is not None:
             md_core_model = util.load_custom_repo_mappings(custom_mappings_path)
             if md_core_model is not None:

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -184,22 +184,13 @@ class Csw(object):
         LOGGER.debug('Model: %s.', self.context.model)
 
         # load user-defined mappings if they exist
-        if self.config.has_option('repository', 'mappings'):
-            # override default repository mappings
-            try:
-                import imp
-                module = self.config.get('repository', 'mappings')
-                if os.sep in module:  # filepath
-                    modulename = '%s' % os.path.splitext(module)[0].replace(
-                        os.sep, '.')
-                    mappings = imp.load_source(modulename, module)
-                else:  # dotted name
-                    mappings = __import__(module, fromlist=[''])
-                LOGGER.info('Loading custom repository mappings '
-                             'from %s', module)
-                self.context.md_core_model = mappings.MD_CORE_MODEL
-                self.context.refresh_dc(mappings.MD_CORE_MODEL)
-            except Exception as err:
+        custom_mappings_path = self.config.get('repository', 'mappings')
+        if custom_mappings_path is not None:
+            md_core_model = util.load_custom_repo_mappings(custom_mappings_path)
+            if md_core_model is not None:
+                self.context.md_core_model = md_core_model
+                self.context.refresh_dc(md_core_model)
+            else:
                 LOGGER.exception('Could not load custom mappings: %s', err)
                 self.response = self.iface.exceptionreport(
                     'NoApplicableCode', 'service',

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -184,7 +184,7 @@ class Csw(object):
         LOGGER.debug('Model: %s.', self.context.model)
 
         # load user-defined mappings if they exist
-        custom_mappings_path = self.config.get('repository', 'mappings', None)
+        custom_mappings_path = self.config.get('repository', 'mappings', fallback=None)
         if custom_mappings_path is not None:
             md_core_model = util.load_custom_repo_mappings(custom_mappings_path)
             if md_core_model is not None:

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -31,6 +31,7 @@
 import datetime as dt
 import os
 import time
+from pathlib import Path
 
 import mock
 import pytest
@@ -340,3 +341,24 @@ def test_jsonify_links(linkstr, expected):
 ])
 def test_is_none_or_empty(value, result):
     assert util.is_none_or_empty(value) is result
+
+
+@pytest.mark.parametrize("import_path, expected_attribute", [
+    pytest.param("itertools", "count", id="import from stdlib"),
+    pytest.param("pycsw.core.admin", "setup_db", id="dotted path import from pycsw"),
+    pytest.param(__file__, "test_programmatic_import", id="filesystem path import"),
+])
+def test_programmatic_import(import_path, expected_attribute):
+    imported_module = util.programmatic_import(import_path)
+    assert getattr(imported_module, expected_attribute)
+
+
+@pytest.mark.parametrize("invalid_import_path", [
+    "dummy",
+    "dummy.submodule",
+    "/non-existent/path",
+    str(Path(__file__).parent / "invalid_path"),
+])
+def test_programmatic_import_with_invalid_path(invalid_import_path):
+    result = util.programmatic_import(invalid_import_path)
+    assert result is None


### PR DESCRIPTION
This PR implements a way to let custom mappings specify additional column constraints for the repository table.

The motivation for this is to allow using a SQL view as the repository table, as discussed in #747.

Implementation consists of a small modification to the way a `pycsw.core.repository.Repository` is initialized. It is now possible to specify an additional `column_constraints` entry in the `MD_CORE_MODEL` variable used to specify custom mappings. These additional column constraints are then passed to the sqlalchemy object that is created as the repository.

It looks something like this:

```python
# file: my_custom_pycsw_mappings.py

from sqlalchemy.schema import PrimaryKeyConstraint

MD_CORE_MODEL = {
    "column_constraints": (
        PrimaryKeyConstraint("identifier"),
    ),
    "typename": "pycsw:CoreMetadata",
    "outputschema": "http://pycsw.org/metadata",
    "mappings": {
        "pycsw:Identifier": "identifier",
        # other mappings omitted for brevity
    },
}
```

In the example provided above, the `PrimaryKeyConstraint("identifier")` is going to be used to let sqlalchemy know which column should be treated as the primary key in the generated table - this particular information is crucial for sqlalchemy to be able to work with DB views. 

IMO this change brings a significant feature to pycsw, since it shall now become possible to use pycsw with third-party projects that store metadata records in a normalized DB form. By enabling pycsw to use a SQL view as its repository table there is now a way to basically make any DB schema conform to the flat structure required by pycsw.

Additional documentation about how to use this new property and a mini-sample of how to create a PostgreSQL materialized view is also included in the docs

fixes #747
fixes #749