### PR TITLE
add OGC GeoRSS 1.0 support to docs

### DIFF
--- a/docs/_templates/indexsidebar.html
+++ b/docs/_templates/indexsidebar.html
@@ -15,6 +15,10 @@
 </p>
 
 <p>
+    <a title="This product conforms to the OGC GeoRSS Encoding Standard version 1.0. OGC, OGC®, and CERTIFIED OGC COMPLIANT are trademarks or registered trademarks of the Open Geospatial Consortium, Inc. in the United States and other countries." href="https://www.opengeospatial.org/resource/products/details/?pid=1374"><img alt="This product conforms to the OGC GeoRSS Encoding Standard version 1.0. OGC, OGC®, and CERTIFIED OGC COMPLIANT are trademarks or registered trademarks of the Open Geospatial Consortium, Inc. in the United States and other countries." src="https://portal.opengeospatial.org/public_ogc/compliance/badge.php?s=GeoRSS%201.0" height="38"/></a>
+</p>
+
+<p>
     <img style="background: white;" alt="OSGeo Project" src="https://raw.githubusercontent.com/OSGeo/osgeo/master/incubation/project/OSGeo_project.png" height="64"/>
 </p>
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -44,6 +44,7 @@ Standards Support
   `OGC OWS Common`_,1.0.0/2.0.0
   `OGC GML`_,3.1.1
   `OGC SFSQL`_,1.2.1
+  `OGC GeoRSS`_,1.0
   `Dublin Core`_,1.1
   `SOAP`_,1.2
   `ISO 19115`_,2003
@@ -205,6 +206,7 @@ Functions
 .. _`OGC SFSQL`: https://www.ogc.org/standards/sfs
 .. _`Dublin Core`: https://www.dublincore.org/
 .. _`OGC CITE CSW`: https://github.com/opengeospatial/ets-csw202
+.. _`OGC GeoRSS`: http://docs.opengeospatial.org/cs/17-002r1/17-002r1.html
 .. _`SOAP`: https://www.w3.org/TR/soap/
 .. _`INSPIRE Discovery Services 3.0`: https://inspire.jrc.ec.europa.eu/documents/Network_Services/TechnicalGuidance_DiscoveryServices_v3.0.pdf
 .. _`ISO 19115`: https://www.iso.org/iso/catalogue_detail.htm?csnumber=26020


### PR DESCRIPTION
# Overview
This PR adds GeoRSS 1.0 compliance/reference implementation status to the docs.

# Related Issue / Discussion
None
# Additional Information
Also added to:
- https://github.com/geopython/pycsw/wiki (Sidebar)
- https://pycsw.org (compliance column)
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
