### PR TITLE
allow vendor specific parameters on .../items queries

### DIFF
--- a/pycsw/ogc/api/oapi.py
+++ b/pycsw/ogc/api/oapi.py
@@ -97,6 +97,17 @@ def gen_oapi(config, oapi_filepath):
         'style': 'form',
         'explode': False
     }
+    oapi['components']['parameters']['filter'] = {
+        'name': 'vendorSpecificParameters',
+        'in': 'query',
+        'description': 'Additional "free-form" parameters that are not explicitly defined',  # noqa
+        'schema': {
+            'type': 'object',
+            'additionalProperties': True
+        },
+        'style': 'form'
+    }
+
     LOGGER.debug('Adding server info')
     oapi['info'] = {
         'contact': {
@@ -226,7 +237,8 @@ def gen_oapi(config, oapi_filepath):
                 {'$ref': '#/components/parameters/sortby'},
                 {'$ref': '#/components/parameters/filter'},
                 {'$ref': '#/components/parameters/f'},
-                {'$ref': '#/components/parameters/offset'}
+                {'$ref': '#/components/parameters/offset'},
+                {'$ref': '#/components/parameters/vendorSpecificParameters'}
             ],
             'responses': {
                 '200': {

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -552,9 +552,6 @@ class API:
         for k, v in args.items():
             if k in reserved_query_params:
                 continue
-            if k not in self.query_mappings and k not in common_query_params:
-                return self.get_exception(
-                    400, headers_, 'InvalidParameterValue', f'Invalid property {k}')
 
             if k not in reserved_query_params:
                 if k == 'anytext':

--- a/tests/unittests/test_oarec_virtual_collections.py
+++ b/tests/unittests/test_oarec_virtual_collections.py
@@ -166,19 +166,19 @@ def test_items(api):
     assert content['numberReturned'] == 10
     assert content['features'][5]['properties']['title'] == 'Lorem ipsum dolor sit amet'  # noqa
 
-    cql_json = {'eq': [{'property': 'title'}, 'Lorem ipsum']}
+    cql_json = {'op': '=', 'args': [{'property': 'title'}, 'Lorem ipsum']}
     content = json.loads(api.items({}, cql_json, {})[2])
     assert content['numberMatched'] == 1
     assert content['numberReturned'] == 1
     assert len(content['features']) == content['numberReturned']
 
-    cql_json = {'eq': [{'property': 'title'}, 'Lorem ipsum']}
+    cql_json = {'op': '=', 'args': [{'property': 'title'}, 'Lorem ipsum']}
     content = json.loads(api.items({}, cql_json, {'limit': 1})[2])
     assert content['numberMatched'] == 1
     assert content['numberReturned'] == 1
     assert len(content['features']) == content['numberReturned']
 
-    cql_json = {'like': [{'property': 'title'}, 'lorem%'], 'nocase': False}
+    cql_json = {'op': 'like', 'args': [{'property': 'title'}, 'lorem%']}
     content = json.loads(api.items({}, cql_json, {})[2])
     assert content['numberMatched'] == 2
     assert content['numberReturned'] == 2


### PR DESCRIPTION
# Overview
Implements OAFeat `/req/core/query-param-unknown` (http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#query_parameters), so that `.../items` queries can accept foreign property names (e.g. cache killers, tokens, etc.).

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
