### PR TITLE
ensure q= queries are case-insensitive

### DIFF
--- a/pycsw/core/pygeofilter_evaluate.py
+++ b/pycsw/core/pygeofilter_evaluate.py
@@ -31,6 +31,7 @@ from sqlalchemy import text
 
 from pygeofilter import ast
 from pygeofilter.backends.evaluator import handle
+from pygeofilter.backends.sqlalchemy import filters
 from pygeofilter.backends.sqlalchemy.evaluate import SQLAlchemyFilterEvaluator
 
 from pycsw.core.util import bbox2wktpolygon
@@ -53,6 +54,15 @@ class PycswFilterEvaluator(SQLAlchemyFilterEvaluator):
             return text(f"ST_Intersects({geometry}, 'SRID={crs};{wkt}')")
         else:
             return text(f"query_spatial({geometry}, '{wkt}', 'bbox', 'false') = 'true'")  # noqa
+
+    @handle(ast.Like)
+    def like(self, node, lhs):
+        return filters.like(
+            lhs,
+            node.pattern,
+            node.nocase,
+            node.not_,
+        )
 
 
 def to_filter(ast, dbtype, field_mapping=None):


### PR DESCRIPTION
# Overview
Updates pygeofilter to always treat "like" queries are case-insensitive.

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
