### PR TITLE
normalize LIKE queries across supported backends

### DIFF
--- a/pycsw/core/pygeofilter_evaluate.py
+++ b/pycsw/core/pygeofilter_evaluate.py
@@ -55,6 +55,20 @@ class PycswFilterEvaluator(SQLAlchemyFilterEvaluator):
         else:
             return text(f"query_spatial({geometry}, '{wkt}', 'bbox', 'false') = 'true'")  # noqa
 
+    @handle(ast.Like)
+    def ilike(self, node, lhs):
+        ci = not node.nocase
+
+        if self._pycsw_dbtype.startswith('sqlite'):
+            ci = node.nocase
+
+        return filters.like(
+            lhs,
+            node.pattern,
+            ci,
+            node.not_,
+        )
+
 
 def to_filter(ast, dbtype, field_mapping=None):
     return PycswFilterEvaluator(field_mapping, dbtype).evaluate(ast)

--- a/pycsw/core/pygeofilter_evaluate.py
+++ b/pycsw/core/pygeofilter_evaluate.py
@@ -55,20 +55,6 @@ class PycswFilterEvaluator(SQLAlchemyFilterEvaluator):
         else:
             return text(f"query_spatial({geometry}, '{wkt}', 'bbox', 'false') = 'true'")  # noqa
 
-    @handle(ast.Like)
-    def ilike(self, node, lhs):
-        ci = not node.nocase
-
-        if self._pycsw_dbtype.startswith('sqlite'):
-            ci = node.nocase
-
-        return filters.like(
-            lhs,
-            node.pattern,
-            ci,
-            node.not_,
-        )
-
 
 def to_filter(ast, dbtype, field_mapping=None):
     return PycswFilterEvaluator(field_mapping, dbtype).evaluate(ast)

--- a/pycsw/core/pygeofilter_evaluate.py
+++ b/pycsw/core/pygeofilter_evaluate.py
@@ -55,15 +55,6 @@ class PycswFilterEvaluator(SQLAlchemyFilterEvaluator):
         else:
             return text(f"query_spatial({geometry}, '{wkt}', 'bbox', 'false') = 'true'")  # noqa
 
-    @handle(ast.Like)
-    def like(self, node, lhs):
-        return filters.like(
-            lhs,
-            node.pattern,
-            node.nocase,
-            node.not_,
-        )
-
 
 def to_filter(ast, dbtype, field_mapping=None):
     return PycswFilterEvaluator(field_mapping, dbtype).evaluate(ast)

--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -42,7 +42,7 @@ try:
 except:
     from shapely.geos import ReadingError
 
-from sqlalchemy import create_engine, event, func, __version__, select
+from sqlalchemy import create_engine, func, __version__, select
 from sqlalchemy.sql import text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import create_session
@@ -56,11 +56,6 @@ LOGGER = logging.getLogger(__name__)
 
 class Repository(object):
     _engines = {}
-
-    def _set_pragmas(self, dbapi_con, con_record):
-        if self.dbtype in ['sqlite', 'sqlite3']:
-            LOGGER.debug('Normalizing SQLite3 LIKE to be case-sensitive')
-            dbapi_con.execute('PRAGMA case_sensitive_like = true')
 
     @classmethod
     def create_engine(clazz, url):
@@ -107,9 +102,6 @@ class Repository(object):
                        'sqlite:///%s%s' % (app_root, os.sep))
 
         self.engine = Repository.create_engine('%s' % database)
-        self.dbtype = self.engine.name
-
-        event.listen(self.engine, 'connect', self._set_pragmas)
 
         base = declarative_base(bind=self.engine)
 
@@ -143,6 +135,8 @@ class Repository(object):
                 "__table_args__": table_args,
             }
         )
+
+        self.dbtype = self.engine.name
 
         self.session = create_session(self.engine)
 
@@ -195,7 +189,6 @@ class Repository(object):
             if not __version__ >= '0.7':
                 self.connection = self.engine.raw_connection()
                 create_custom_sql_functions(self.connection)
-            self.session.execute("PRAGMA case_sensitive_like=true")
 
         LOGGER.info('setting repository queryables')
         # generate core queryables db and obj bindings

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -968,9 +968,9 @@ def build_anytext(name, value):
     tokens = value.split()
 
     if len(tokens) == 1:  # single term
-        return f"{name} LIKE '%{value}%'"
+        return f"{name} ILIKE '%{value}%'"
 
     for token in tokens:
-        predicates.append(f"{name} LIKE '%{token}%'")
+        predicates.append(f"{name} ILIKE '%{token}%'")
 
     return f"({' AND '.join(predicates)})"

--- a/pycsw/ogc/api/templates/item.html
+++ b/pycsw/ogc/api/templates/item.html
@@ -2,7 +2,7 @@
 {% block title %}{{ super() }} {{ data['properties']['externalId'] }} {% endblock %}
 {% block extrahead %}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
-    <script src="http://code.jquery.com/jquery-3.6.0.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
     <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
     <style>
         #records-map {

--- a/pycsw/ogc/api/templates/items.html
+++ b/pycsw/ogc/api/templates/items.html
@@ -3,7 +3,7 @@
 
 {% block extrahead %}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
-    <script src="http://code.jquery.com/jquery-3.6.0.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
     <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
     <style>
         #records-map {

--- a/pycsw/ogc/api/templates/stac_items.html
+++ b/pycsw/ogc/api/templates/stac_items.html
@@ -3,7 +3,7 @@
 
 {% block extrahead %}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
-    <script src="http://code.jquery.com/jquery-3.6.0.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
     <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
     <style>
         #records-map {

--- a/tests/gen_html.py
+++ b/tests/gen_html.py
@@ -49,7 +49,7 @@ print('''
                 border: 0px;
             }
         </style>
-        <script type="text/javascript" src="http://code.jquery.com/jquery-%s.min.js"></script>
+        <script type="text/javascript" src="https://code.jquery.com/jquery-%s.min.js"></script>
         <script type="text/javascript">
             $(document).ready(function() {
                 $('.xml').change(function() {
@@ -150,8 +150,8 @@ print('''
             </ul>
         <hr/>
         <footer>
-            <a href="http://validator.w3.org/check?verbose=1&amp;uri=referer" title="Valid HTML 5!"><img class="flat" src="http://www.w3.org/html/logo/downloads/HTML5_Badge_32.png" alt="Valid HTML 5!" height="32" width="32"/></a>
-            <a href="http://jigsaw.w3.org/css-validator/check/referer" title="Valid CSS!"><img class="flat" src="http://jigsaw.w3.org/css-validator/images/vcss-blue" alt="Valid CSS!" height="31" width="88"/></a>
+            <a href="https://validator.w3.org/check?verbose=1&amp;uri=referer" title="Valid HTML 5!"><img class="flat" src="https://www.w3.org/html/logo/downloads/HTML5_Badge_32.png" alt="Valid HTML 5!" height="32" width="32"/></a>
+            <a href="https://jigsaw.w3.org/css-validator/check/referer" title="Valid CSS!"><img class="flat" src="https://jigsaw.w3.org/css-validator/images/vcss-blue" alt="Valid CSS!" height="31" width="88"/></a>
         </footer>
     </body>
 </html>


### PR DESCRIPTION
# Overview
This PR updates the following OARec query semantics:
- normalizes `LIKE` behaviour across DB backends to be case-sensitive (per PostgreSQL)
- ensures any `q=` queries translate to `ILIKE` (case-insensitive) for DB backends

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
