### PR TITLE
set OARec keyword searches to CQL ILIKE

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -558,6 +558,8 @@ class API:
                     query_args.append(build_anytext(k, v))
                 elif k == 'bbox':
                     query_args.append(f'BBOX(geometry, {v})')
+                elif k == 'keywords':
+                    query_args.append(f"keywords ILIKE '%{v}%'")
                 elif k == 'datetime':
                     if '/' not in v:
                         query_args.append(f'date = "{v}"')


### PR DESCRIPTION
# Overview
Intercepts OARec items `keywords=` queries and transforms into CQL `ILIKE` predicate.

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
