### PR TITLE
parse ISO gmd:function and set as OARec link relation

### DIFF
--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1506,7 +1506,8 @@ def _parse_iso(context, repos, exml):
                 'name': link.name,
                 'description': link.description,
                 'protocol': link.protocol,
-                'url': link.url
+                'url': link.url,
+                'function': link.function
             })
 
     try:

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -927,8 +927,8 @@ def record2json(record, stac_item=False):
             }
             if 'rel' in link:
                 link2['rel'] = link['rel']
-            elif 'type' in link and 'rel' not in link:
-                link2['rel'] = link['type']
+            elif 'function' in link:
+                link2['rel'] = link['function']
 
             rdl.append(link2)
 


### PR DESCRIPTION
# Overview
Updates ISO parser to use `gmd:function` and sets as OARec link relation when proper link relation is not defined.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
