### PR TITLE
emit logs to stdout if logfile not defined

### DIFF
--- a/pycsw/core/log.py
+++ b/pycsw/core/log.py
@@ -59,15 +59,13 @@ def setup_logger(config=None):
 
     logfile = None
     loglevel = 'NOTSET'
-
     logging_handlers = []
 
-    if config.has_option('server', 'loglevel'):
-        loglevel = config.get('server', 'loglevel')
+    loglevel = config.get('server', 'loglevel', fallback=loglevel)
 
-        if loglevel not in LOGLEVELS.keys():
-            raise RuntimeError(
-                'Invalid server configuration (server.loglevel).')
+    if loglevel not in LOGLEVELS.keys():
+        raise RuntimeError(
+            'Invalid server configuration (server.loglevel).')
 
     if loglevel != 'NOTSET':
         if config.has_option('server', 'logfile'):

--- a/pycsw/core/log.py
+++ b/pycsw/core/log.py
@@ -29,7 +29,6 @@
 # =================================================================
 
 import logging
-import sys
 
 LOGGER = logging.getLogger(__name__)
 
@@ -61,6 +60,8 @@ def setup_logger(config=None):
     logfile = None
     loglevel = 'NOTSET'
 
+    logging_handlers = []
+
     if config.has_option('server', 'loglevel'):
         loglevel = config.get('server', 'loglevel')
 
@@ -68,24 +69,19 @@ def setup_logger(config=None):
             raise RuntimeError(
                 'Invalid server configuration (server.loglevel).')
 
-        if not config.has_option('server', 'logfile'):
-            logging.basicConfig(level=LOGLEVELS[loglevel], datefmt=TIME_FORMAT,
-                                format=MSG_FORMAT, stream=sys.stdout)
-
-    if config.has_option('server', 'logfile'):
-        if not config.has_option('server', 'loglevel'):
-            raise RuntimeError(
-                'Invalid server configuration (server.logfile set,\
-                but server.loglevel missing).')
-
-        logfile = config.get('server', 'logfile')
+    if loglevel != 'NOTSET':
+        if config.has_option('server', 'logfile'):
+            logfile = config.get('server', 'logfile')
+            logging_handlers.append(logging.FileHandler(logfile))
+        else:  # stdout
+            logging_handlers.append(logging.StreamHandler())
 
         # Setup logging globally (not only for the pycsw module)
         # based on the parameters passed.
         logging.basicConfig(level=LOGLEVELS[loglevel],
-                            filename=logfile,
+                            format=MSG_FORMAT,
                             datefmt=TIME_FORMAT,
-                            format=MSG_FORMAT)
+                            handlers=logging_handlers)
 
     LOGGER.info('Logging initialized (level: %s).', loglevel)
 

--- a/pycsw/core/log.py
+++ b/pycsw/core/log.py
@@ -29,6 +29,7 @@
 # =================================================================
 
 import logging
+import sys
 
 LOGGER = logging.getLogger(__name__)
 
@@ -68,9 +69,8 @@ def setup_logger(config=None):
                 'Invalid server configuration (server.loglevel).')
 
         if not config.has_option('server', 'logfile'):
-            raise RuntimeError(
-                'Invalid server configuration (server.loglevel set,\
-                but server.logfile missing).')
+            logging.basicConfig(level=LOGLEVELS[loglevel], datefmt=TIME_FORMAT,
+                                format=MSG_FORMAT, stream=sys.stdout)
 
     if config.has_option('server', 'logfile'):
         if not config.has_option('server', 'loglevel'):
@@ -80,17 +80,12 @@ def setup_logger(config=None):
 
         logfile = config.get('server', 'logfile')
 
-    if loglevel != 'NOTSET' and logfile is None:
-        raise RuntimeError(
-            'Invalid server configuration \
-            (server.loglevel set, but server.logfile is not).')
-
-    # Setup logging globally (not only for the pycsw module)
-    # based on the parameters passed.
-    logging.basicConfig(level=LOGLEVELS[loglevel],
-                        filename=logfile,
-                        datefmt=TIME_FORMAT,
-                        format=MSG_FORMAT)
+        # Setup logging globally (not only for the pycsw module)
+        # based on the parameters passed.
+        logging.basicConfig(level=LOGLEVELS[loglevel],
+                            filename=logfile,
+                            datefmt=TIME_FORMAT,
+                            format=MSG_FORMAT)
 
     LOGGER.info('Logging initialized (level: %s).', loglevel)
 

--- a/tests/functionaltests/conftest.py
+++ b/tests/functionaltests/conftest.py
@@ -214,7 +214,6 @@ def configuration(request, tests_directory, log_level):
                              test_dir=tests_directory,
                              export_dir=export_dir)
     config.set("server", "loglevel", log_level)
-    config.set("server", "logfile", "")
     config.set("repository", "database", repository_url)
     config.set("repository", "table", table_name)
     return config


### PR DESCRIPTION
# Overview
This PR updates logging functionality such that if `server.loglevel` is defined (but `server.logfile` is not), then logging is emitted to stdout.  If `server.logfile` is defined, then logging is written to file as usual/expected.

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
