### PR TITLE
mark unit tests for execution (#792)

### DIFF
--- a/tests/unittests/test_fmt_json.py
+++ b/tests/unittests/test_fmt_json.py
@@ -86,7 +86,7 @@ def test_xml2dict():
         "ows": "http://www.opengis.net/ows/2.0",
         "xsi": "http://www.w3.org/2001/xmlschema-instance",
         "dc": "http://purl.org/dc/elements/1.1/",
-        "dct":"http://purl.org/dc/terms/",
+        "dct": "http://purl.org/dc/terms/",
     }
     result = fmt_json.xml2dict(xml_string=xml, namespaces=namespaces)
     assert result["csw:GetRecordsResponse"]["csw:SearchResults"][

--- a/tests/unittests/test_oarec.py
+++ b/tests/unittests/test_oarec.py
@@ -1,3 +1,34 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#          Angelos Tzotsos <gcpp.kalxas@gmail.com>
+#
+# Copyright (c) 2022 Tom Kralidis
+# Copyright (c) 2022 Angelos Tzotsos
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
 import json
 import os
 from xml.etree import ElementTree as etree
@@ -6,6 +37,8 @@ import pytest
 
 from pycsw.core.util import parse_ini_config
 from pycsw.ogc.api.records import API
+
+pytestmark = pytest.mark.unit
 
 
 def get_test_file_path(filename):

--- a/tests/unittests/test_oarec_transactions.py
+++ b/tests/unittests/test_oarec_transactions.py
@@ -1,3 +1,32 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#
+# Copyright (c) 2022 Tom Kralidis
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
 import json
 import os
 from xml.etree import ElementTree as etree
@@ -6,6 +35,8 @@ import pytest
 
 from pycsw.core.util import parse_ini_config
 from pycsw.ogc.api.records import API
+
+pytestmark = pytest.mark.unit
 
 
 def get_test_file_path(filename):

--- a/tests/unittests/test_oarec_virtual_collections.py
+++ b/tests/unittests/test_oarec_virtual_collections.py
@@ -1,3 +1,34 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#          Angelos Tzotsos <gcpp.kalxas@gmail.com>
+#
+# Copyright (c) 2022 Tom Kralidis
+# Copyright (c) 2022 Angelos Tzotsos
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
 import json
 import os
 from xml.etree import ElementTree as etree
@@ -6,6 +37,8 @@ import pytest
 
 from pycsw.core.util import parse_ini_config
 from pycsw.ogc.api.records import API
+
+pytestmark = pytest.mark.unit
 
 
 def get_test_file_path(filename):

--- a/tests/unittests/test_opensearch.py
+++ b/tests/unittests/test_opensearch.py
@@ -58,4 +58,5 @@ pytestmark = pytest.mark.unit
 ])
 def test_validate_4326(bbox, expected):
     result = opensearch.validate_4326(bbox)
+
     assert result == expected

--- a/tests/unittests/test_stac_api.py
+++ b/tests/unittests/test_stac_api.py
@@ -1,3 +1,34 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#          Angelos Tzotsos <gcpp.kalxas@gmail.com>
+#
+# Copyright (c) 2022 Tom Kralidis
+# Copyright (c) 2022 Angelos Tzotsos
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
 import json
 import os
 
@@ -5,6 +36,8 @@ import pytest
 
 from pycsw.core.util import parse_ini_config
 from pycsw.ogc.api.records import API
+
+pytestmark = pytest.mark.unit
 
 
 def get_test_file_path(filename):

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -86,6 +86,7 @@ def test_get_version_integer_invalid_version(invalid_version):
     with pytest.raises(RuntimeError):
         util.get_version_integer(invalid_version)
 
+
 @pytest.mark.parametrize("xpath_expression, expected", [
     ("ns1:first", "{something}first"),
     ("ns1:first/ns2:second", "{something}first/{other}second"),
@@ -114,6 +115,7 @@ def test_nspath_eval_invalid_element():
             }
         )
 
+
 @pytest.mark.parametrize("envelope, expected", [
     ("ENVELOPE (-180,180,90,-90)", "-180,-90,180,90"),
     (" ENVELOPE(-180,180,90,-90)", "-180,-90,180,90"),
@@ -122,6 +124,7 @@ def test_nspath_eval_invalid_element():
 def test_wktenvelope2bbox(envelope, expected):
     result = util.wktenvelope2bbox(envelope)
     assert result == expected
+
 
 # TODO - Add more WKT cases for other geometry types
 @pytest.mark.parametrize("wkt, bounds, expected", [
@@ -192,8 +195,8 @@ def test_getqattr_link():
 
 
 def test_getqattr_invalid():
-        result = util.getqattr(dt.date(2017, 1, 1), "name")
-        assert result is None
+    result = util.getqattr(dt.date(2017, 1, 1), "name")
+    assert result is None
 
 
 def test_http_request_post():
@@ -250,6 +253,7 @@ def test_ipaddress_in_whitelist(ip, whitelist, expected):
     result = util.ipaddress_in_whitelist(ip, whitelist)
     assert result == expected
 
+
 @pytest.mark.parametrize("linkstr, expected", [
     # old style CSV
     ("roads,my roads,OGC:WMS,http://example.org/wms",
@@ -285,7 +289,7 @@ def test_ipaddress_in_whitelist(ip, whitelist, expected):
          "description": "my roads",
          "protocol": "OGC:WMS",
          "url": "http://example.org/wms"
-      },{
+      }, {
          "name": "roads",
          "description": "my roads",
          "protocol": "OGC:WFS",
@@ -303,28 +307,28 @@ def test_ipaddress_in_whitelist(ip, whitelist, expected):
     ),
     # JSON style with some empty keys
     ('[{"name": "roads", "description": null, "protocol": "OGC:WMS", "url": "http://example.org/wms"}]',
-     [{
-         "name": "roads",
-         "description": None,
-         "protocol": "OGC:WMS",
-         "url": "http://example.org/wms"
-      }]
+        [{
+            "name": "roads",
+            "description": None,
+            "protocol": "OGC:WMS",
+            "url": "http://example.org/wms"
+        }]
     ),
     # JSON style with multiple links
     ('[{"name": "roads", "description": null, "protocol": "OGC:WMS", "url": "http://example.org/wms"},'
      '{"name": "roads", "description": null, "protocol": "OGC:WFS", "url": "http://example.org/wfs"}]',
-     [{
-         "name": "roads",
-         "description": None,
-         "protocol": "OGC:WMS",
-         "url": "http://example.org/wms"
-      },{
-         "name": "roads",
-         "description": None,
-         "protocol": "OGC:WFS",
-         "url": "http://example.org/wfs"
-      }]
-    )
+        [{
+            "name": "roads",
+            "description": None,
+            "protocol": "OGC:WMS",
+            "url": "http://example.org/wms"
+         }, {
+            "name": "roads",
+            "description": None,
+            "protocol": "OGC:WFS",
+            "url": "http://example.org/wfs"
+        }]
+     )
 ])
 def test_jsonify_links(linkstr, expected):
     result = util.jsonify_links(linkstr)

--- a/tests/unittests/test_wsgi.py
+++ b/tests/unittests/test_wsgi.py
@@ -37,6 +37,7 @@ from pycsw import wsgi
 
 pytestmark = pytest.mark.unit
 
+
 @pytest.mark.parametrize("process_env, wsgi_env, fake_dir, expected", [
     ({}, None, "dummy", "dummy"),
     ({"PYCSW_ROOT": "this"}, None, "dummy", "this"),


### PR DESCRIPTION
# Overview
Adds pytest marker to OARec and STAC tests for tox execution, as well as some flake8 / source code header updates.

# Related Issue / Discussion
#792 
# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
