### PR TITLE
adds externalIds and preview link  to record-geojson

### DIFF
--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1322,7 +1322,7 @@ def _parse_iso(context, repos, exml):
     _set(context, recobj, 'pycsw:XML', md.xml)
     _set(context, recobj, 'pycsw:MetadataType', 'application/xml')
     _set(context, recobj, 'pycsw:AnyText', util.get_anytext(exml))
-    _set(context, recobj, 'pycsw:Language', md.language)
+    _set(context, recobj, 'pycsw:Language', md.language or md.languagecode)
     _set(context, recobj, 'pycsw:Type', md.hierarchy)
     _set(context, recobj, 'pycsw:ParentIdentifier', md.parentidentifier)
     _set(context, recobj, 'pycsw:Date', md.datestamp)
@@ -1352,6 +1352,8 @@ def _parse_iso(context, repos, exml):
 
         if len(md.identification.resourcelanguage) > 0:
             _set(context, recobj, 'pycsw:ResourceLanguage', md.identification.resourcelanguage[0])
+        elif len(md.identification.resourcelanguagecode) > 0:
+            _set(context, recobj, 'pycsw:ResourceLanguage', md.identification.resourcelanguagecode[0])
 
         if hasattr(md.identification, 'bbox'):
             bbox = md.identification.bbox
@@ -1527,6 +1529,15 @@ def _parse_iso(context, repos, exml):
                         links.append(linkobj)
     except Exception as err:  # srv: identification does not exist
         LOGGER.exception('no srv:SV_ServiceIdentification links found')
+
+    if hasattr(md.identification, 'graphicoverview'):
+        for thumb in  md.identification.graphicoverview:
+            links.append({
+                'name': 'preview',
+                'description': 'Web image thumbnail (URL)',
+                'protocol': 'WWW:LINK-1.0-http--image-thumbnail',
+                'url': thumb
+            })
 
     if len(links) > 0:
         _set(context, recobj, 'pycsw:Links', json.dumps(links))

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -986,6 +986,10 @@ def record2json(record, url, collection, stac_item=False):
     if record.language:
         record_dict['properties']['language'] = record.language
 
+    #externalids: [{scheme:xxx, value:yyy}]
+    if record.source:
+        record_dict['properties']['externalIds'] = [{'value': record.source}]
+
     if record.title:
         record_dict['properties']['title'] = record.title
 
@@ -1008,9 +1012,11 @@ def record2json(record, url, collection, stac_item=False):
                 'description': link['description'],
                 'type': link['protocol']
             }
-            if 'rel' in link:
+            if 'rel' in link.keys():
                 link2['rel'] = link['rel']
-            elif 'function' in link:
+            elif link['protocol'] == 'WWW:LINK-1.0-http--image-thumbnail':
+                link2['rel'] = 'preview'
+            elif 'function' in link.keys():
                 link2['rel'] = link['function']
 
             rdl.append(link2)
@@ -1021,7 +1027,7 @@ def record2json(record, url, collection, stac_item=False):
         'title': 'Collection',
         'name': 'collection',
         'description': 'Collection',
-        'href': f"{url}/collections/{collection}?f=json"
+        'href': f"{url}/collections/{collection}"
     })
 
     if record.wkt_geometry:

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1027,8 +1027,6 @@ def record2json(record, url, collection, stac_item=False):
         'href': f"{url}/collections/{collection}"
     })
 
-    print(vars(record))
-
     if record.wkt_geometry:
         minx, miny, maxx, maxy = wkt2geom(record.wkt_geometry)
         geometry = {
@@ -1041,24 +1039,16 @@ def record2json(record, url, collection, stac_item=False):
                 [minx, miny]
             ]]
         }
-        record_dict['extent'] = {
-            'spatial': { 
-                'bbox': [minx, miny, maxx, maxy],
-                'crs': 'http://www.opengis.net/def/crs/OGC/1.3/CRS84' }
-        }
         record_dict['geometry'] = geometry
 
     if record.time_begin or record.time_end:
-        if 'extent' not in record_dict:
-            record_dict['extent'] = {}
-        record_dict['extent']['temporal'] = {
-            'interval': [],
-            'trs': 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian' }
-        if record.time_begin:
-            record_dict['extent']['temporal']['interval'].append(record.time_begin)
-        if record.time_end:
-            record_dict['extent']['temporal']['interval'].append(record.time_end)
-
+        if record.time_end not in [None, '']:
+            if record.time_begin not in [None, '']:
+                record_dict['time'] = [record.time_begin, record.time_end]
+            else:
+                record_dict['time'] = record.time_end
+        else:
+            record_dict['time'] = record.time_begin
 
     return record_dict
 

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -959,11 +959,8 @@ def record2json(record, url, collection, stac_item=False):
         'id': record.identifier,
         'type': 'Feature',
         'geometry': None,
-        'properties': {
-            'datetime': record.date,
-            'start_datetime': record.time_begin,
-            'end_datetime': record.time_end
-        },
+        'time': record.date,
+        'properties': {},
         'links': [],
         'assets': {}
     }
@@ -1012,11 +1009,11 @@ def record2json(record, url, collection, stac_item=False):
                 'description': link['description'],
                 'type': link['protocol']
             }
-            if 'rel' in link.keys():
+            if 'rel' in link:
                 link2['rel'] = link['rel']
             elif link['protocol'] == 'WWW:LINK-1.0-http--image-thumbnail':
                 link2['rel'] = 'preview'
-            elif 'function' in link.keys():
+            elif 'function' in link:
                 link2['rel'] = link['function']
 
             rdl.append(link2)
@@ -1030,6 +1027,8 @@ def record2json(record, url, collection, stac_item=False):
         'href': f"{url}/collections/{collection}"
     })
 
+    print(vars(record))
+
     if record.wkt_geometry:
         minx, miny, maxx, maxy = wkt2geom(record.wkt_geometry)
         geometry = {
@@ -1042,7 +1041,24 @@ def record2json(record, url, collection, stac_item=False):
                 [minx, miny]
             ]]
         }
+        record_dict['extent'] = {
+            'spatial': { 
+                'bbox': [minx, miny, maxx, maxy],
+                'crs': 'http://www.opengis.net/def/crs/OGC/1.3/CRS84' }
+        }
         record_dict['geometry'] = geometry
+
+    if record.time_begin or record.time_end:
+        if 'extent' not in record_dict:
+            record_dict['extent'] = {}
+        record_dict['extent']['temporal'] = {
+            'interval': [],
+            'trs': 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian' }
+        if record.time_begin:
+            record_dict['extent']['temporal']['interval'].append(record.time_begin)
+        if record.time_end:
+            record_dict['extent']['temporal']['interval'].append(record.time_end)
+
 
     return record_dict
 

--- a/pycsw/ogc/api/templates/item.html
+++ b/pycsw/ogc/api/templates/item.html
@@ -58,6 +58,14 @@
                 {% endfor %}
                 </ul>
               </td>
+            {% elif key == 'externalIds' %}
+            <td>
+              <ul>
+                {% for id in value %}
+                <li>{{ id['scheme'] | urlize }} {{ id['value'] | urlize }}</li>
+                {% endfor %}
+              </ul>
+            </td>
             {% elif key == 'extent' %}
               <td>Spatial: {{ value['spatial']['bbox'][0] }}</td>
               {% if value['temporal'] %}<td>Temporal: {{ value['temporal']['interval'][0] }}</td>{% endif %}

--- a/pycsw/ogc/api/templates/item.html
+++ b/pycsw/ogc/api/templates/item.html
@@ -66,14 +66,17 @@
                 {% endfor %}
               </ul>
             </td>
-            {% elif key == 'extent' %}
-              <td>Spatial: {{ value['spatial']['bbox'][0] }}</td>
-              {% if value['temporal'] %}<td>Temporal: {{ value['temporal']['interval'][0] }}</td>{% endif %}
             {% else %}
               <td>{{ value }}</td>
             {% endif %}
           </tr>
           {% endfor %}
+          {% if data['time'] %}
+          <tr>
+            <td>Temporal</td>
+            <td>{{ data['time'] }}</td>
+          </tr>
+          {% endif %}
           <tr>
             <td>Links</td>
             <td>

--- a/tests/functionaltests/suites/apiso/expected/post_GetRecordById-full-dc.xml
+++ b/tests/functionaltests/suites/apiso/expected/post_GetRecordById-full-dc.xml
@@ -33,10 +33,12 @@
     <dct:references>http://oos.soest.hawaii.edu/erddap/tabledap/nss06_agg.graph?time%2Ctemperature&amp;.draw=lines</dct:references>
     <dct:references>http://pacioos.org/focus/waterquality/wq_fsm.php</dct:references>
     <dct:references>http://oos.soest.hawaii.edu/thredds/dodsC/pacioos/nss/ns06agg</dct:references>
+    <dct:references scheme="WWW:LINK-1.0-http--image-thumbnail">http://pacioos.org/metadata/browse/NS06agg.png</dct:references>
     <dc:relation></dc:relation>
     <dct:modified>2014-04-16</dct:modified>
     <dct:abstract>The nearshore sensors are part of the Pacific Islands Ocean Observing System (PacIOOS) and are designed to measure a variety of ocean parameters at fixed point locations. NS06 is located at the dock in Pohnpei lagoon and is mounted to the bottom in about 1 meter of water. The instrument is a Sea-Bird Electronics model 16+ V2 coupled with a WET Labs ECO-FLNTUS combination sensor.</dct:abstract>
     <dc:date>2014-04-16</dc:date>
+    <dc:language>eng</dc:language>
     <ows:BoundingBox crs="urn:x-ogc:def:crs:EPSG:6.11:4326" dimensions="2">
       <ows:LowerCorner>6.96 158.22</ows:LowerCorner>
       <ows:UpperCorner>6.96 158.22</ows:UpperCorner>


### PR DESCRIPTION
# Overview

- Record-geojson has a field externalIds [{schema:xxx,value:yyy}] to capture remote identifications of the resource. 
- Thumbnail links are included as a link of rel=preview. this PR adds both aspects to the record geojson encoding, based on existing pycsw properties (it does not introduce new pycsw field).
- While building the record json, it takes langaugecode if language is not populated

# Related Issue / Discussion

pycsw currently uses the source field for resource identification (based on md.identification.dataseturi). Future improvements: a namespace is not yet captured on pycsw database, this is for example used in wms capabilities authority:identifier (see also https://github.com/geopython/OWSLib/issues/841) but also on iso as md.identification.identifier.namespace

the preview link is build up from links with the `WWW:LINK-1.0-http--image-thumbnail` protocol, as currently used in wms-thumbnails. I currently don't populate type (image/png or jpg) maybe it can be build by parsing the url. Future work: add the thumbnail as an image to the items and item views

# Additional Information


# Contributions and Licensing

- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
