### PR TITLE
Handle STAC Item collection property and assign to ParentIdentifier

### DIFF
--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1755,6 +1755,9 @@ def _parse_stac_item(context, repos, record):
     if 'end_datetime' in record['properties']:
         _set(context, recobj, 'pycsw:TempExtent_end', record['properties']['end_datetime'])
 
+    if 'collection' in record:
+        _set(context, recobj, 'pycsw:ParentIdentifier', record['collection'])
+
     return recobj
 
 


### PR DESCRIPTION
# Overview

STAC Item parser is currently not handling the collection information from the collection property.
This PR adds support for this property and assigns to the ParentIdentifier column so that virtual collections will pick up this relation.

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
