### PR TITLE
Fix various OGC API Records and STAC Item link issues

### DIFF
--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1679,6 +1679,8 @@ def _parse_oarec_record(context, repos, record):
             if link.get('title') is not None:
                 new_link['name'] = link.get('title')
                 new_link['description'] = link.get('title')
+            if link.get('description') is not None:
+                new_link['description'] = link.get('description')
             if link.get('type') is not None:
                 new_link['protocol'] = link.get('type')
             if link.get('rel') is not None:
@@ -1726,6 +1728,24 @@ def _parse_stac_item(context, repos, record):
     if 'keywords' in record['properties']:
         keywords = record['properties']['keywords']
         _set(context, recobj, 'pycsw:Keywords', ','.join(keywords))
+
+    if 'links' in record:
+        for link in record['links']:
+            new_link = {
+                'url': link.get('href')
+            }
+
+            if link.get('title') is not None:
+                new_link['name'] = link.get('title')
+                new_link['description'] = link.get('title')
+            if link.get('description') is not None:
+                new_link['description'] = link.get('description')
+            if link.get('type') is not None:
+                new_link['protocol'] = link.get('type')
+            if link.get('rel') is not None:
+                new_link['function'] = link.get('rel')
+
+            links.append(new_link)
 
     if 'assets' in record:
         for key, link in record['assets'].items():

--- a/pycsw/ogc/api/templates/item.html
+++ b/pycsw/ogc/api/templates/item.html
@@ -71,7 +71,17 @@
             <td>
               <ul>
                 {% for link in data['links'] %}
-                <li><a href="{{ link['href'] }}" title="{{ link['description'] }}">{{ link['name'] }}</a></li>
+                  {% if link['name'] %}
+                    {% if link['description'] %}
+                      <li><a href="{{ link['href'] }}" title="{{ link['description'] }}">{{ link['name'] }}</a></li>
+                    {% else %}
+                      <li><a href="{{ link['href'] }}" title="{{ link['name'] }}">{{ link['name'] }}</a></li>
+                    {% endif %}
+                  {% elif link['description'] %}
+                    <li><a href="{{ link['href'] }}" title="{{ link['description'] }}">{{ link['description'] }}</a></li>
+                  {% else %}
+                    <li><a href="{{ link['href'] }}" title="{{ link['rel'] }}">{{ link['rel'] }}</a></li>
+                  {% endif %}
                 {% endfor %}
               </ul>
           </tr>
@@ -81,7 +91,7 @@
             <td>
               <ul>
                 {% for key, value in data['assets'].items() %}
-                  {%if value['title'] %}
+                  {% if value['title'] %}
                     <li><a href="{{ value['href'] }}" title="{{ value['title'] }}">{{ key }}</a></li>
                   {% else %}
                     <li><a href="{{ value['href'] }}" title="{{ key }}">{{ key }}</a></li>


### PR DESCRIPTION
# Overview

* Safeguard link template for name and description missing
* Support links in STAC Item parser

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
