### PR TITLE
prevent template error if contact['roles'] is string type

### DIFF
--- a/pycsw/ogc/api/templates/item.html
+++ b/pycsw/ogc/api/templates/item.html
@@ -80,7 +80,15 @@
             {% elif key == 'providers' %}
               <td>
                 {% for cnt in data['properties']['providers'] %}
-                {{ cnt['name'] }} ({{ cnt.get('roles',[{}])[0].get('name','') }}/{{ cnt['positionName'] }})<br/>
+                  {% if 'name' in cnt and cnt['name'] not in [None,''] %}
+                    {{ cnt['name'] }} <br/>
+                  {% endif %}
+                  {% if 'roles' in cnt and cnt['roles'] is not string %}
+                  Role: {{ cnt['roles'] | map(attribute='name') | join(',') }} <br/>
+                  {% endif %}
+                  {% if 'positionName' in cnt and cnt['positionName'] not in [None,''] %}
+                  Position: {{ cnt['positionName'] }})<br/>
+                  {% endif %}
                   {% for k,e in cnt['contactInfo'].get('phone',{}).items() %}
                     {% if e %}{{ k }}: {{ e }}<br/>{% endif %}
                   {% endfor %}


### PR DESCRIPTION
# Overview

extra check on roles!=string in item template

# Related Issue / Discussion

@kalxas reported a string error in item.html
![image](https://user-images.githubusercontent.com/299829/206565076-a0f74c49-f363-43eb-bc71-634195e068df.png)
this pr improves the code, to make it more robust

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
