### PR TITLE
populate the contacts field for fgdc metadata

### DIFF
--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1137,9 +1137,21 @@ def _parse_fgdc(context, repos, exml):
         _set(context, recobj, 'pycsw:Creator', md.idinfo.origin)
         _set(context, recobj, 'pycsw:Publisher',  md.idinfo.origin)
         _set(context, recobj, 'pycsw:Contributor', md.idinfo.origin)
-
+    
+    contacts = []
     if hasattr(md.idinfo, 'ptcontac'):
         _set(context, recobj, 'pycsw:OrganizationName', md.idinfo.ptcontac.cntorg)
+        contacts.append(fgdccontact2iso(md.idinfo.ptcontac, 'pointOfContact'))
+    
+    if hasattr(md.metainfo, 'metc'):
+        contacts.append(fgdccontact2iso(md.metainfo.metc, 'pointOfContact'))
+    
+    if hasattr(md.distinfo, 'distrib'):
+        contacts.append(fgdccontact2iso(md.distinfo.distrib, 'distributor'))
+    
+    if len(contacts) > 0:
+        _set(context, recobj, 'pycsw:Contacts', json.dumps(contacts))
+
     _set(context, recobj, 'pycsw:AccessConstraints', md.idinfo.accconst)
     _set(context, recobj, 'pycsw:OtherConstraints', md.idinfo.useconst)
     _set(context, recobj, 'pycsw:Date', md.metainfo.metd)
@@ -1799,6 +1811,21 @@ def _parse_stac_item(context, repos, record):
 
     return recobj
 
+def fgdccontact2iso(cnt, role='pointOfContact'):
+    """Creates a iso format contact (owslib style) from fgdc format"""
+
+    return {'name': cnt.cntper, 
+            'organization': cnt.cntorg, 
+            'position': cnt.cntpos, 
+            'phone': cnt.voice, 
+            'address': cnt.address, 
+            'city': cnt.city, 
+            'region': cnt.state,
+            'postcode': cnt.postal, 
+            'country': cnt.country, 
+            'email': cnt.email, 
+            'role': role
+    }
 
 def caps2iso(record, caps, context):
     """Creates ISO metadata from Capabilities XML"""

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1015,22 +1015,22 @@ def record2json(record, url, collection, stac_item=False):
         rcnt = []
         for cnt in json.loads(record.contacts):
             rcnt.append({
-                'name': ' - '.join(filter(None,[cnt['name'], cnt['organization']])),
-                'positionName': cnt['position'],
+                'name': ' - '.join(filter(None,[cnt.get('name',''), cnt.get('organization','')])),
+                'positionName': cnt.get('position',''),
                 'roles': [
-                    {'name':cnt['role']}
+                    {'name':cnt.get('role','')}
                 ],
                 'contactInfo': {
-                    'phone': {'work': cnt['phone']},
-                    'email': {'work':cnt['email']},
+                    'phone': {'work': cnt.get('phone','')},
+                    'email': {'work':cnt.get('email','')},
                     'address': {'work': { 
-                            'deliveryPoint': cnt['address'],
-                            'city': cnt['city'],
-                            'administrativeArea': cnt['region'],
-                            'postalCode': cnt['postcode'],
-                            'country': cnt['country'],
+                            'deliveryPoint': cnt.get('address',''),
+                            'city': cnt.get('city',''),
+                            'administrativeArea': cnt.get('region',''),
+                            'postalCode': cnt.get('postcode',''),
+                            'country': cnt.get('country',''),
                     }},
-                    'url': cnt['onlineresource']
+                    'url': {'href': cnt.get('onlineresource',{}).get('url','')}
                 }   
             })
         record_dict['properties']['providers'] = rcnt

--- a/pycsw/ogc/api/templates/item.html
+++ b/pycsw/ogc/api/templates/item.html
@@ -89,17 +89,19 @@
                   {% if 'positionName' in cnt and cnt['positionName'] not in [None,''] %}
                   Position: {{ cnt['positionName'] }})<br/>
                   {% endif %}
-                  {% for k,e in cnt['contactInfo'].get('phone',{}).items() %}
-                    {% if e %}{{ k }}: {{ e }}<br/>{% endif %}
-                  {% endfor %}
-                  {% for k,e in cnt['contactInfo'].get('email',{}).items() %}
-                    {% if e not in [None,''] %}{{ k }}: {{ e | urlize }}<br/>{% endif %}
-                  {% endfor %}
-                  {% for k,e in cnt['contactInfo'].get('address',{}).items() %}
-                    {{ k }}: {% for a,b in e.items() %}{% if b %}{{ b }}, {% endif %}{% endfor %}<br/>
-                  {% endfor %}
-                  {% if cnt['contactInfo']['url'] %}
-                    <a href="{{ cnt['contactInfo']['url'] | urlize }}">{{ cnt['url'] }}</a>
+                  {% if 'contactInfo' in cnt and cnt['contactInfo'] is not string %}
+                    {% for k,e in cnt['contactInfo'].get('phone',{}).items() %}
+                      {% if e %}{{ k }}: {{ e }}<br/>{% endif %}
+                    {% endfor %}
+                    {% for k,e in cnt['contactInfo'].get('email',{}).items() %}
+                      {% if e not in [None,''] %}{{ k }}: {{ e | urlize }}<br/>{% endif %}
+                    {% endfor %}
+                    {% for k,e in cnt['contactInfo'].get('address',{}).items() %}
+                      {{ k }}: {% for a,b in e.items() %}{% if b %}{{ b }}, {% endif %}{% endfor %}<br/>
+                    {% endfor %}
+                    {% if cnt['contactInfo']['url'] %}
+                      {{ cnt['contactInfo']['url'].get('href','') | urlize }}
+                    {% endif %} 
                   {% endif %} 
                 {% endfor %} 
               </td>


### PR DESCRIPTION
# Overview

- populate the contacts field for fgdc metadata, 
- makes the geojson generation more robust, in case certain properties are not populated on the metadata object

# Related Issue / Discussion

this improves one aspect of #827

while developing, i noticed OWSLib can be improved to capture more contact details:
https://github.com/geopython/OWSLib/pull/849, merge of PR is not required for this work to function

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
