### PR TITLE
Add option to run simpler WSGI app

### DIFF
--- a/default-sample.cfg
+++ b/default-sample.cfg
@@ -45,6 +45,7 @@ gzip_compresslevel=9
 #spatial_ranking=true
 profiles=apiso
 #workers=2
+#flask_app="False"
 
 [manager]
 transactions=false

--- a/default-sample.cfg
+++ b/default-sample.cfg
@@ -45,7 +45,7 @@ gzip_compresslevel=9
 #spatial_ranking=true
 profiles=apiso
 #workers=2
-#flask_app="False"
+flask_app=true
 
 [manager]
 transactions=false

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -116,7 +116,8 @@ def launch_pycsw(pycsw_config, workers=2, reload=False, flask_app=True):
             python_app,
         ]
     )
-    logger.debug("Launching pycsw with {} ...".format(" ".join(execution_args)))
+    logger.debug("Launching pycsw with {} ...".format(
+        " ".join(execution_args)))
     os.execlp("gunicorn", *execution_args)
 
 
@@ -128,13 +129,15 @@ def handle_sqlite_db(database_url, table_name, pycsw_home):
         except OSError as exc:
             if exc.args[0] == 17:  # directory already exists
                 pass
-        admin.setup_db(database=database_url, table=table_name, home=pycsw_home)
+        admin.setup_db(database=database_url,
+                       table=table_name, home=pycsw_home)
 
 
 def handle_postgresql_db(database_url, table_name, pycsw_home):
     _wait_for_postgresql_db(database_url)
     try:
-        admin.setup_db(database=database_url, table=table_name, home=pycsw_home)
+        admin.setup_db(database=database_url,
+                       table=table_name, home=pycsw_home)
     except ProgrammingError:
         pass  # database tables are already created
 
@@ -201,4 +204,5 @@ if __name__ == "__main__":
         flask_app = args.flask_app
     logging.basicConfig(level=getattr(logging, level))
     print(flask_app)
-    launch_pycsw(config, workers=workers, flask_app=flask_app, reload=args.reload)
+    launch_pycsw(config, workers=workers,
+                 flask_app=flask_app, reload=args.reload)

--- a/docker/pycsw.cfg
+++ b/docker/pycsw.cfg
@@ -48,6 +48,7 @@ loglevel=DEBUG
 profiles=apiso
 #workers=2
 timeout=30
+flask_app=true
 
 [manager]
 transactions=false


### PR DESCRIPTION
 Add option to run simpler WSGI app instead of flask  app in the docker entry-point

# Overview

Adds an entry in the configure to decide which app `wsgi` or `wsgi.flask` should run via the docker entrypoint

# Related Issue / Discussion

The flask app at the moment depends on the pycsw backend (e.g.: PostgreSQL, SQLite ) - the actual entrypoint doesn't have an option to run the simpler wsgi app to deploy a csw service

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
