### PR TITLE
Add temporal support to STAC Collection parser

### DIFF
--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1803,7 +1803,7 @@ def _parse_stac_resource(context, repos, record):
             bbox_wkt = util.bbox2wktpolygon(bbox_csv)
         else:
             bbox_wkt = None
-        if 'extent' in record and 'temporal' in record['extent']:
+        if 'extent' in record and 'temporal' in record['extent'] and 'interval' in record['extent']['temporal']:
             _set(context, recobj, 'pycsw:TempExtent_begin', record['extent']['temporal']['interval'][0][0])
             _set(context, recobj, 'pycsw:TempExtent_end', record['extent']['temporal']['interval'][0][1])
     elif stac_type == 'Catalog':

--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1803,6 +1803,9 @@ def _parse_stac_resource(context, repos, record):
             bbox_wkt = util.bbox2wktpolygon(bbox_csv)
         else:
             bbox_wkt = None
+        if 'extent' in record and 'temporal' in record['extent']:
+            _set(context, recobj, 'pycsw:TempExtent_begin', record['extent']['temporal']['interval'][0][0])
+            _set(context, recobj, 'pycsw:TempExtent_end', record['extent']['temporal']['interval'][0][1])
     elif stac_type == 'Catalog':
         LOGGER.debug('Parsing STAC Catalog')
         conformance = 'https://github.com/radiantearth/stac-spec/tree/master/catalog-spec/catalog-spec.md'


### PR DESCRIPTION
# Overview
STAC Collection requires that a temporal extent object must be present (https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#temporal-extent-object).
This PR adds support to parse the first temporal object (according to the STAC specification "The first time interval always describes the overall temporal extent of the data.")

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
