### PR TITLE
update STAC API support to v1.0.0-rc.4

### DIFF
--- a/docs/stac.rst
+++ b/docs/stac.rst
@@ -6,7 +6,7 @@ SpatioTemporal Asset Catalog (STAC) API Support
 Versions
 --------
 
-pycsw supports `SpatioTemporal Asset Catalog API version v1.0.0-rc.3`_ by default.
+pycsw supports `SpatioTemporal Asset Catalog API version v1.0.0-rc.4`_ by default.
 
 pycsw implements provides STAC support in the following manner:
 

--- a/docs/stac.rst
+++ b/docs/stac.rst
@@ -6,7 +6,7 @@ SpatioTemporal Asset Catalog (STAC) API Support
 Versions
 --------
 
-pycsw supports `SpatioTemporal Asset Catalog API version 1.0.0-beta2`_ by default.
+pycsw supports `SpatioTemporal Asset Catalog API version v1.0.0-rc.3`_ by default.
 
 pycsw implements provides STAC support in the following manner:
 
@@ -75,4 +75,4 @@ JSON and HTML output formats are both supported via the ``f`` parameter.
   http://localhost:8000/collections/metadata:main/items/{itemId}?f=xml
 
 
-.. _`SpatioTemporal Asset Catalog API version 1.0.0-beta2`: https://github.com/radiantearth/stac-api-spec
+.. _`SpatioTemporal Asset Catalog API version v1.0.0-rc.4`: https://github.com/radiantearth/stac-api-spec

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -69,8 +69,6 @@ CONFORMANCE_CLASSES = [
     'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/json',
     'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/html',
     'http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2',
-    'http://www.opengis.net/spec/cql2/1.0/conf/cql2-text',
-    'http://www.opengis.net/spec/cql2/1.0/conf/cql2-json',
     'https://api.stacspec.org/v1.0.0-rc.4/core',
     'https://api.stacspec.org/v1.0.0-rc.4/item-search',
     'https://api.stacspec.org/v1.0.0-rc.4/ogcapi-features'

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -69,9 +69,11 @@ CONFORMANCE_CLASSES = [
     'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/json',
     'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/html',
     'http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2',
-    'https://api.stacspec.org/v1.0.0-rc.2/core',
-    'https://api.stacspec.org/v1.0.0-rc.2/item-search',
-    'https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features#sort'
+    'http://www.opengis.net/spec/cql2/1.0/conf/cql2-text',
+    'http://www.opengis.net/spec/cql2/1.0/conf/cql2-json',
+    'https://api.stacspec.org/v1.0.0-rc.4/core',
+    'https://api.stacspec.org/v1.0.0-rc.4/item-search',
+    'https://api.stacspec.org/v1.0.0-rc.4/ogcapi-features'
 ]
 
 
@@ -714,6 +716,12 @@ class API:
             'type': 'application/json',
             'title': 'Collection URL',
             'href': f"{self.config['server']['url']}/collections/{collection}",
+            'hreflang': self.config['server']['language']
+        }, {
+            'rel': 'root',
+            'type': 'application/json',
+            'title': 'The root URI as JSON',
+            'href': f"{self.config['server']['url']}/?f=json",
             'hreflang': self.config['server']['language']
         }])
 

--- a/tests/unittests/test_oarec.py
+++ b/tests/unittests/test_oarec.py
@@ -125,7 +125,7 @@ def test_items(api):
     content = json.loads(api.items({}, None, {})[2])
 
     assert content['type'] == 'FeatureCollection'
-    assert len(content['links']) == 4
+    assert len(content['links']) == 5
     assert content['numberMatched'] == 12
     assert content['numberReturned'] == 10
     assert len(content['features']) == 10

--- a/tests/unittests/test_oarec_virtual_collections.py
+++ b/tests/unittests/test_oarec_virtual_collections.py
@@ -128,7 +128,7 @@ def test_items(api):
     content = json.loads(api.items({}, None, {})[2])
 
     assert content['type'] == 'FeatureCollection'
-    assert len(content['links']) == 4
+    assert len(content['links']) == 5
     assert content['numberMatched'] == 12
     assert content['numberReturned'] == 10
     assert len(content['features']) == 10

--- a/tests/unittests/test_stac_api.py
+++ b/tests/unittests/test_stac_api.py
@@ -89,8 +89,8 @@ def test_conformance(api):
 
     assert len(content['conformsTo']) == 13
 
-    assert 'https://api.stacspec.org/v1.0.0-rc.2/core' in content['conformsTo']  # noqa
-    assert 'https://api.stacspec.org/v1.0.0-rc.2/item-search' in content['conformsTo']  # noqa
+    assert 'https://api.stacspec.org/v1.0.0-rc.4/core' in content['conformsTo']  # noqa
+    assert 'https://api.stacspec.org/v1.0.0-rc.4/item-search' in content['conformsTo']  # noqa
 
 
 def test_items(api):


### PR DESCRIPTION
# Overview
STAC API updates based on [v1.0.0-rc.3](https://github.com/radiantearth/stac-api-spec/releases/tag/v1.0.0-rc.3) and [v1.0.0-rc.4](https://github.com/radiantearth/stac-api-spec/releases/tag/v1.0.0-rc.4)
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
