### PR TITLE
update Filter and CQL2 support based on specification updates

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -9,6 +9,8 @@ Features
 ========
 
 - implements `OGC API - Records - Part 1: Core`_
+- implements `OGC API - Features - Part 3: Filtering`_
+- implements `Common Query Language (CQL2)`_
 - certified OGC `Compliant`_ and OGC Reference Implementation for both CSW 2.0.2 and CSW 3.0.0
 - harvesting support for WMS, WFS, WCS, WPS, WAF, CSW, SOS
 - implements `INSPIRE Discovery Services 3.0`_
@@ -38,7 +40,7 @@ Standards Support
   :header: Standard,Version(s)
 
   `OGC API - Records - Part 1: Core`_,1.0
-  `OGC API - Features - Part 3: Filtering and the Common Query Language (CQL)`_,draft
+  `OGC API - Features - Part 3: Filtering`_,draft
   "`OGC API - Features - Part 4: Create, Replace, Update and Delete`_",draft
   `OGC CSW`_,2.0.2/3.0.0
   `OGC Filter`_,1.1.0/2.0.0
@@ -66,8 +68,13 @@ OGC API - Records support
 OGC API - Features support
 --------------------------
 
-- Part 3: Filtering and the Common Query Language (CQL)
+- Part 3: Filtering
 - Part 4: Create, Replace, Update and Delete
+
+CQL
+---
+
+- Common Query Language (CQL2)
 
 Supported Output Formats
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,7 +87,7 @@ Supported Filters
 
 - q
 - datetime
-- filter (CQL)
+- filter / filter-lang (CQL)
 - bbox
 - all properties (``property=value``)
 
@@ -199,7 +206,8 @@ Functions
 - upper
 
 .. _`OGC API - Records - Part 1: Core`: https://ogcapi.ogc.org/records
-.. _`OGC API - Features - Part 3: Filtering and the Common Query Language (CQL)`: http://docs.ogc.org/DRAFTS/19-079.html
+.. _`OGC API - Features - Part 3: Filtering`: http://docs.ogc.org/DRAFTS/19-079.html
+.. _`Common Query Language (CQL2)`: https://docs.ogc.org/DRAFTS/21-065.html
 .. _`OGC CSW`: https://www.ogc.org/standards/cat
 .. _`ISO Metadata Application Profile 1.0.0`: https://portal.ogc.org/files/?artifact_id=21460
 .. _`OGC Filter`: https://www.ogc.org/standards/filter

--- a/docs/oarec-support.rst
+++ b/docs/oarec-support.rst
@@ -52,7 +52,7 @@ JSON and HTML output formats are both supported via the ``f`` parameter.
   # collection query, property query
   http://localhost:8000/collections/metadata:main/items?title=Lorem%20ipsum
   # collection query, CQL filter
-  http://localhost:8000/collections/metadata:main/items?filter=title LIKE '%lorem%'
+  http://localhost:8000/collections/metadata:main/items?filter-lang=cql-text&filter=title LIKE '%lorem%'
   # collection query, limiting results
   http://localhost:8000/collections/metadata:main/items?limit=1
   # collection query, paging

--- a/pycsw/ogc/api/oapi.py
+++ b/pycsw/ogc/api/oapi.py
@@ -97,6 +97,22 @@ def gen_oapi(config, oapi_filepath):
         'style': 'form',
         'explode': False
     }
+    oapi['components']['parameters']['filter-lang'] = {
+        'name': 'filter-lang',
+        'in': 'query',
+        'description': 'The optional filter-lang parameter specifies the predicate language of the filter being applied',  # noqa
+        'required': False,
+        'schema': {
+            'type': 'string',
+            'enum': [
+                'cql2-json',
+                'cql2-text',
+            ],
+            'default': 'cql2-text'
+        },
+        'style': 'form',
+        'explode': False
+    }
     oapi['components']['parameters']['vendorSpecificParameters'] = {
         'name': 'vendorSpecificParameters',
         'in': 'query',
@@ -236,6 +252,7 @@ def gen_oapi(config, oapi_filepath):
                 {'$ref': '#/components/parameters/externalId'},
                 {'$ref': '#/components/parameters/sortby'},
                 {'$ref': '#/components/parameters/filter'},
+                {'$ref': '#/components/parameters/filter-lang'},
                 {'$ref': '#/components/parameters/f'},
                 {'$ref': '#/components/parameters/offset'},
                 {'$ref': '#/components/parameters/vendorSpecificParameters'}

--- a/pycsw/ogc/api/oapi.py
+++ b/pycsw/ogc/api/oapi.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2021 Tom Kralidis
+# Copyright (c) 2023 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -58,6 +58,69 @@ def gen_oapi(config, oapi_filepath):
         'name': 'Metadata',
         'description': 'access to metadata (records)'
     }]
+
+    LOGGER.debug('Adding response components')
+    oapi['components']['responses']['Queryables'] = {
+        'content': {
+            'application/json': {
+                'schema': {
+                    '$ref': '#/components/schemas/queryables'
+                }
+            }
+        },
+        'description': 'successful queryables operation'
+    }
+    oapi['components']['schemas']['queryable'] = {
+        'properties': {
+            'description': {
+                'description': 'a human-readable narrative describing the queryable',  # noqa
+                'type': 'string'
+            },
+            'language': {
+                'default': [
+                    'en'
+                ],
+                'description': 'the language used for the title and description',  # noqa
+                'type': 'string'
+            },
+            'queryable': {
+                'description': 'the token that may be used in a CQL predicate',
+                'type': 'string'
+            },
+            'title': {
+                'description': 'a human readable title for the queryable',
+                'type': 'string'
+            },
+            'type': {
+                'description': 'the data type of the queryable',
+                'type': 'string'
+            },
+            'type-ref': {
+                'description': 'a reference to the formal definition of the type',  # noqa
+                'format': 'url',
+                'type': 'string'
+            }
+        },
+        'required': [
+            'queryable',
+            'type'
+        ],
+        'type': 'object'
+    }
+    oapi['components']['schemas']['queryables'] = {
+        'properties': {
+            'queryables': {
+                'items': {
+                    '$ref': '#/components/schemas/queryable'
+                },
+                'type': 'array'
+            }
+        },
+        'required': [
+            'queryables'
+        ],
+        'type': 'object'
+    }
 
     LOGGER.debug('Adding parameter components')
     oapi['components']['parameters']['f'] = {
@@ -155,7 +218,7 @@ def gen_oapi(config, oapi_filepath):
             ],
             'responses': {
                 '200': {
-                    '$ref': '#/components/responses/LandingPage'
+                    '$ref': '#/components/responses/Queryables'
                 },
                 '500': {
                     '$ref': '#/components/responses/ServerError'
@@ -235,6 +298,39 @@ def gen_oapi(config, oapi_filepath):
     }
 
     oapi['paths']['/collections/{collectionId}'] = path
+
+    path = {
+        'get': {
+            'tags': ['Queryables'],
+            'summary': 'Queryables page',
+            'description': 'Queryables page',
+            'operationId': 'getQueryables',
+            'parameters': [
+                {'$ref': '#/components/parameters/f'}
+            ],
+            'responses': {
+                '200': {
+                    '$ref': '#/components/responses/Queryables'
+                },
+                '500': {
+                    '$ref': '#/components/responses/ServerError'
+                }
+            }
+        }
+    }
+
+    oapi['paths']['/queryables'] = path
+
+    path2 = deepcopy(path)
+
+    path2['get']['operationId'] = 'getCollectionQueryables'
+    path2['get']['parameters'].append(
+        {'$ref': '#/components/parameters/collectionId'})
+    path2['get']['responses']['404'] = {
+        '$ref': '#/components/responses/NotFound'
+    }
+
+    oapi['paths']['/collections/{collectionId}/queryables'] = path2
 
     path = {
         'get': {

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -3,7 +3,7 @@
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #          Angelos Tzotsos <tzotsos@gmail.com>
 #
-# Copyright (c) 2022 Tom Kralidis
+# Copyright (c) 2023 Tom Kralidis
 # Copyright (c) 2021 Angelos Tzotsos
 #
 # Permission is hereby granted, free of charge, to any person
@@ -75,6 +75,7 @@ CONFORMANCE_CLASSES = [
     'http://www.opengis.net/spec/cql2/1.0/conf/cql2-text',
     'https://api.stacspec.org/v1.0.0-rc.4/core',
     'https://api.stacspec.org/v1.0.0-rc.4/item-search',
+    'https://api.stacspec.org/v1.0.0-rc.2/item-search#filter',
     'https://api.stacspec.org/v1.0.0-rc.4/ogcapi-features'
 ]
 
@@ -309,6 +310,11 @@ class API:
               'type': 'application/xml',
               'title': 'SRU endpoint',
               'href': f"{self.config['server']['url']}/sru"
+            }, {
+              'rel': 'http://www.opengis.net/def/rel/ogc/1.0/queryables',
+              'type': 'application/schema+json',
+              'title': 'Queryables',
+              'href': f"{self.config['server']['url']}/queryables"
             }, {
               'rel': 'child',
               'type': 'application/json',

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -62,13 +62,17 @@ CONFORMANCE_CLASSES = [
     'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core',
     'http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections',
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core',
+    'http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables',
+    'http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables-query-parameters',  # noqa
     'http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter',
+    'http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter',
     'http://www.opengis.net/spec/ogcapi-features-4/1.0/conf/create-replace-delete',  # noqa
     'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/core',
     'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/sorting',
     'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/json',
     'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/html',
-    'http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2',
+    'http://www.opengis.net/spec/cql2/1.0/conf/cql2-json',
+    'http://www.opengis.net/spec/cql2/1.0/conf/cql2-text',
     'https://api.stacspec.org/v1.0.0-rc.4/core',
     'https://api.stacspec.org/v1.0.0-rc.4/item-search',
     'https://api.stacspec.org/v1.0.0-rc.4/ogcapi-features'
@@ -447,6 +451,18 @@ class API:
             'title': 'This document as HTML',
             'href': f"{url_base}?f=html",
             'hreflang': self.config['server']['language']
+        }, {
+            'rel': 'http://www.opengis.net/def/rel/ogc/1.0/queryables',
+            'type': 'application/schema+json',
+            'title': 'Queryables as JSON',
+            'href': f"{url_base}/queryables?f=json",
+            'hreflang': self.config['server']['language']
+        }, {
+            'rel': 'http://www.opengis.net/def/rel/ogc/1.0/queryables',
+            'type': 'text/html',
+            'title': 'Queryables as HTML',
+            'href': f"{url_base}/queryables?f=html",
+            'hreflang': self.config['server']['language']
         }]
 
         return self.get_response(200, headers_, 'collection.html', response)
@@ -463,6 +479,9 @@ class API:
         """
 
         headers_['Content-Type'] = self.get_content_type(headers_, args)
+
+        if 'json' in headers_['Content-Type']:
+            headers_['Content-Type'] = 'application/schema+json'
 
         properties = self.repository.describe()
         properties2 = {}
@@ -506,9 +525,15 @@ class API:
         reserved_query_params = [
             'f',
             'filter',
+            'filter-lang',
             'limit',
             'sortby',
             'offset'
+        ]
+
+        filter_langs = [
+            'cql2-json',
+            'cql2-text'
         ]
 
         response = {
@@ -545,6 +570,11 @@ class API:
         if 'filter' in args:
             LOGGER.debug(f'CQL query specified {args["filter"]}')
             cql_query = args['filter']
+            filter_lang = args.get('filter-lang')
+            if filter_lang is not None and filter_lang not in filter_langs:
+                msg = f'Invalid filter-lang'
+                LOGGER.exception(msg)
+                return self.get_exception(400, headers_, 'InvalidParameterValue', msg)
 
         LOGGER.debug('Transforming property filters into CQL')
         query_args = []

--- a/pycsw/wsgi_flask.py
+++ b/pycsw/wsgi_flask.py
@@ -3,7 +3,7 @@
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #          Angelos Tzotsos <tzotsos@gmail.com>
 #
-# Copyright (c) 2022 Tom Kralidis
+# Copyright (c) 2023 Tom Kralidis
 # Copyright (c) 2021 Angelos Tzotsos
 #
 # Permission is hereby granted, free of charge, to any person
@@ -130,6 +130,7 @@ def collection(collection='metadata:main'):
                         request.args, collection))
 
 
+@BLUEPRINT.route('/queryables')
 @BLUEPRINT.route('/collections/<collection>/queryables')
 def queryables(collection='metadata:main'):
     """

--- a/pycsw/wsgi_flask.py
+++ b/pycsw/wsgi_flask.py
@@ -162,7 +162,7 @@ def items(collection='metadata:main'):
     if 'search' in request.url_rule.rule:
         stac_item = True
 
-    if request.method == 'POST' and request.content_type not in [None, 'application/json']:
+    if request.method == 'POST' and request.content_type not in [None, 'application/json']:  # noqa
         if request.content_type == 'application/geo+json':  # JSON grammar
             data = request.get_json(silent=True)
         elif 'xml' in request.content_type:  # XML grammar

--- a/tests/unittests/test_oarec.py
+++ b/tests/unittests/test_oarec.py
@@ -3,7 +3,7 @@
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #          Angelos Tzotsos <gcpp.kalxas@gmail.com>
 #
-# Copyright (c) 2022 Tom Kralidis
+# Copyright (c) 2023 Tom Kralidis
 # Copyright (c) 2022 Angelos Tzotsos
 #
 # Permission is hereby granted, free of charge, to any person
@@ -66,7 +66,7 @@ def test_landing_page(api):
 
     assert headers['Content-Type'] == 'application/json'
     assert status == 200
-    assert len(content['links']) == 14
+    assert len(content['links']) == 15
 
     for link in content['links']:
         assert link['href'].startswith(api.config['server']['url'])
@@ -90,7 +90,7 @@ def test_openapi(api):
 def test_conformance(api):
     content = json.loads(api.conformance({}, {})[2])
 
-    assert len(content['conformsTo']) == 17
+    assert len(content['conformsTo']) == 18
 
 
 def test_collections(api):

--- a/tests/unittests/test_oarec.py
+++ b/tests/unittests/test_oarec.py
@@ -90,7 +90,7 @@ def test_openapi(api):
 def test_conformance(api):
     content = json.loads(api.conformance({}, {})[2])
 
-    assert len(content['conformsTo']) == 13
+    assert len(content['conformsTo']) == 17
 
 
 def test_collections(api):

--- a/tests/unittests/test_oarec_virtual_collections.py
+++ b/tests/unittests/test_oarec_virtual_collections.py
@@ -3,7 +3,7 @@
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #          Angelos Tzotsos <gcpp.kalxas@gmail.com>
 #
-# Copyright (c) 2022 Tom Kralidis
+# Copyright (c) 2023 Tom Kralidis
 # Copyright (c) 2022 Angelos Tzotsos
 #
 # Permission is hereby granted, free of charge, to any person
@@ -69,7 +69,7 @@ def test_landing_page(api):
 
     assert headers['Content-Type'] == 'application/json'
     assert status == 200
-    assert len(content['links']) == 14
+    assert len(content['links']) == 15
 
     for link in content['links']:
         assert link['href'].startswith(api.config['server']['url'])
@@ -93,7 +93,7 @@ def test_openapi(api):
 def test_conformance(api):
     content = json.loads(api.conformance({}, {})[2])
 
-    assert len(content['conformsTo']) == 17
+    assert len(content['conformsTo']) == 18
 
 
 def test_collections(api):

--- a/tests/unittests/test_oarec_virtual_collections.py
+++ b/tests/unittests/test_oarec_virtual_collections.py
@@ -93,7 +93,7 @@ def test_openapi(api):
 def test_conformance(api):
     content = json.loads(api.conformance({}, {})[2])
 
-    assert len(content['conformsTo']) == 13
+    assert len(content['conformsTo']) == 17
 
 
 def test_collections(api):

--- a/tests/unittests/test_stac_api.py
+++ b/tests/unittests/test_stac_api.py
@@ -69,7 +69,7 @@ def test_landing_page(api):
 
     assert content['stac_version'] == '1.0.0'
     assert content['type'] == 'Catalog'
-    assert len(content['conformsTo']) == 13
+    assert len(content['conformsTo']) == 17
     assert len(content['keywords']) == 3
 
 
@@ -87,7 +87,7 @@ def test_openapi(api):
 def test_conformance(api):
     content = json.loads(api.conformance({}, {})[2])
 
-    assert len(content['conformsTo']) == 13
+    assert len(content['conformsTo']) == 17
 
     assert 'https://api.stacspec.org/v1.0.0-rc.4/core' in content['conformsTo']  # noqa
     assert 'https://api.stacspec.org/v1.0.0-rc.4/item-search' in content['conformsTo']  # noqa

--- a/tests/unittests/test_stac_api.py
+++ b/tests/unittests/test_stac_api.py
@@ -3,7 +3,7 @@
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #          Angelos Tzotsos <gcpp.kalxas@gmail.com>
 #
-# Copyright (c) 2022 Tom Kralidis
+# Copyright (c) 2023 Tom Kralidis
 # Copyright (c) 2022 Angelos Tzotsos
 #
 # Permission is hereby granted, free of charge, to any person
@@ -65,11 +65,11 @@ def test_landing_page(api):
 
     assert headers['Content-Type'] == 'application/json'
     assert status == 200
-    assert len(content['links']) == 14
+    assert len(content['links']) == 15
 
     assert content['stac_version'] == '1.0.0'
     assert content['type'] == 'Catalog'
-    assert len(content['conformsTo']) == 17
+    assert len(content['conformsTo']) == 18
     assert len(content['keywords']) == 3
 
 
@@ -87,7 +87,7 @@ def test_openapi(api):
 def test_conformance(api):
     content = json.loads(api.conformance({}, {})[2])
 
-    assert len(content['conformsTo']) == 17
+    assert len(content['conformsTo']) == 18
 
     assert 'https://api.stacspec.org/v1.0.0-rc.4/core' in content['conformsTo']  # noqa
     assert 'https://api.stacspec.org/v1.0.0-rc.4/item-search' in content['conformsTo']  # noqa


### PR DESCRIPTION
# Overview
This PR updates support for OGC API - Features - Part 4: Filtering and Common Query Language (CQL2)
- add support for `.../items` `filter-lang` parameter
- add `.../items` `filter-lang` parameter to OpenAPI document
- fixup conformance declarations
  - NOTE: for CQL2, only "leaf" conformance classes are provided (i.e. `cql2-json` and `cql-text`) of which both depend on  `basic-cql2`.  `basic-cql2` is therefore removed given the dependence / implicitly
- adds STAC queryables extension and OpenAPI definitions.

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
