### PR TITLE
orm type should be specified at Repository level (#856)

### DIFF
--- a/pycsw/core/config.py
+++ b/pycsw/core/config.py
@@ -46,6 +46,7 @@ class StaticContext(object):
         self.ogc_schemas_base = 'http://schemas.opengis.net'
 
         self.parser = PARSER
+        self.server = None
 
         self.languages = {
             'en': 'english',

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -134,6 +134,8 @@ class Csw(object):
         self.context.pycsw_home = self.config.get('server', 'home')
         self.context.url = self.config.get('server', 'url')
 
+        self.context.server = self
+
         log.setup_logger(self.config)
 
         LOGGER.info('running configuration %s', rtconfig)


### PR DESCRIPTION
# Overview

Add the server instance in context so that custom Repository can manage its properties

# Related Issue / Discussion

- Issue: #856
- PR for 2.6: https://github.com/geopython/pycsw/pull/857

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute the feature discussed in #865 to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
