### PR TITLE
this creates a list of formats, from online.protocol, to improve #870

### DIFF
--- a/tests/functionaltests/suites/apiso/expected/post_GetRecordById-full-dc.xml
+++ b/tests/functionaltests/suites/apiso/expected/post_GetRecordById-full-dc.xml
@@ -26,6 +26,7 @@
     <dc:subject>longitude</dc:subject>
     <dc:subject>time</dc:subject>
     <dc:subject scheme="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_TopicCategoryCode">climatologyMeteorologyAtmosphere</dc:subject>
+    <dc:format>WWW:LINK</dc:format>
     <dct:references>http://oos.soest.hawaii.edu/thredds/idd/nss_pacioos.html?dataset=NS06agg</dct:references>
     <dct:references scheme="WWW:LINK">http://oos.soest.hawaii.edu/thredds/dodsC/pacioos/nss/ns06agg.html</dct:references>
     <dct:references>http://pacioos.org/voyager/index.html?b=6.874279%2C158.077126%2C7.050468%2C158.369808&amp;tz=pont&amp;o=qual:2::p0NS06p1</dct:references>


### PR DESCRIPTION
# Overview
a suggestion to include iso:distribution/online/protocol in the pycsw:format field, so its content can be used in filters on format

# Related Issue / Discussion
issue #870 

# Additional Information

also fixes a problem on uom

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
