### PR TITLE
add record links to ogc-api records item

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -33,7 +33,7 @@ from configparser import ConfigParser
 import json
 import logging
 import os
-from urllib.parse import urlencode
+from urllib.parse import urlencode, quote
 
 from pygeofilter.parsers.ecql import parse as parse_ecql
 from pygeofilter.parsers.cql2_json import parse as parse_cql2_json
@@ -1116,6 +1116,18 @@ def record2json(record, url, collection, stac_item=False):
                 link2['rel'] = link['function']
 
             rdl.append(link2)
+
+    for lnk in [record.parentidentifier, record.relation]:
+        if lnk and len(lnk.strip()) > 0:
+            if not lnk.startswith('http'):
+                lnk = f"{url}/collections/{collection}/items/{quote(lnk)}"
+            record_dict['links'].append({
+                'href': lnk,
+                'name': 'Related record',
+                'description': '',
+                'type': 'text/html'
+            })
+    
 
     record_dict['links'].append({
         'rel': 'collection',

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1122,10 +1122,11 @@ def record2json(record, url, collection, stac_item=False):
             if not lnk.startswith('http'):
                 lnk = f"{url}/collections/{collection}/items/{quote(lnk)}"
             record_dict['links'].append({
+                'rel': 'related',
                 'href': lnk,
-                'name': 'Related record',
-                'description': '',
-                'type': 'text/html'
+                'name': 'related record',
+                'description': 'related record',
+                'type': 'application/json'
             })
     
 


### PR DESCRIPTION
# Overview

this introduces values from rec.relation and rec.parentidentifier as links on an ogcapi-records item, it is a first iteration of the changes suggested in #850

q: can parentidentifier/relation have multiple links (separated by ',')? in that case i need to consider that case in code
q: should I add link with ?f=html as well as ?f=json
q: makes sense to query db for existince of uuid, to include also title/abstract/lang as part of this PR?

# Related Issue / Discussion

#850

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
