### PR TITLE
remove stopwords from anytext filter

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1164,6 +1164,8 @@ def build_anytext(name, value):
 
     predicates = []
     tokens = value.split()
+    stopwords = ['i','me','my','myself','we','our','ours','ourselves','you','your','yours','yourself','yourselves','he','him','his','himself','she','her','hers','herself','it','its','itself','they','them','their','theirs','themselves','what','which','who','whom','this','that','these','those','am','is','are','was','were','be','been','being','have','has','had','having','do','does','did','doing','a','an','the','and','but','if','or','because','as','until','while','of','at','by','for','with','about','against','between','into','through','during','before','after','above','below','to','from','up','down','in','out','on','off','over','under','again','further','then','once','here','there','when','where','why','how','all','any','both','each','few','more','most','other','some','such','no','nor','not','only','own','same','so','than','too','very','s','t','can','will','just','don','should','now'] # noqa
+    tokens = list(filter(lambda el: el not in stopwords, tokens))
 
     if len(tokens) == 1:  # single term
         return f"{name} ILIKE '%{value}%'"


### PR DESCRIPTION
# Overview

initial rough implementation to improve #879 

q: seems only relevant to postgres, because fulltextsearch does not exist in plain sqlite.
q: it's probably better to retrieve stopwords from postgres, to prevent asynchronity, but also support stopwords for other languages ( i have not found how)


# Related Issue / Discussion

#879

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
