### PR TITLE
[WIP] use a single fts query, not by word

### DIFF
--- a/pycsw/core/pygeofilter_evaluate.py
+++ b/pycsw/core/pygeofilter_evaluate.py
@@ -66,7 +66,7 @@ class PycswFilterEvaluator(SQLAlchemyFilterEvaluator):
         if (str(lhs.prop) == 'dataset.anytext' and
                 self._pycsw_dbtype.startswith('postgres')):
             LOGGER.debug('Kicking into PostgreSQL FTS mode')
-            return text(f"plainto_tsquery('english', '{node.pattern}') @@ anytext_tsvector")  # noqa
+            return text(f"to_tsquery('english', '{node.pattern}') @@ anytext_tsvector")  # noqa
         else:
             LOGGER.debug('Default ILIKE behaviour')
             return filters.like(

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1167,8 +1167,7 @@ def build_anytext(name, value):
 
     if len(tokens) == 1:  # single term
         return f"{name} ILIKE '%{value}%'"
-
-    for token in tokens:
-        predicates.append(f"{name} ILIKE '%{token}%'")
-
-    return f"({' AND '.join(predicates)})"
+    else:
+        # on each term use fuzzy match: ts_query(beer:* & wine:*)
+        ts_query = " & ".join([t + ':*' for t in tokens])
+        return f"{name} ILIKE '{ts_query}'"


### PR DESCRIPTION
# Overview

on anytext searches with multiple words, instead of creating multiple where clauses this creates a single where clause with a ts-query having fuzzy matching for each term. this is not valid CQL, but final results are good (on postgres, for sqlite an alternative solution is needed). I would like to hear from you what you think, are there other ways to bypass the cql syntax, because ts-query doesn't really fit with CQL...

# Related Issue / Discussion

#879

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
