### PR TITLE
#891 Fix requirements (geolinks/click dependency)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ OWSLib<0.29
 pyproj
 Shapely<2.0
 xmltodict
+
+# see #891
+click


### PR DESCRIPTION
# Overview

Workaround for [geolinks](https://github.com/geopython/geolinks/issues/13) for creating a runnable image.

The docker image created on the live 2.6 branch will not run (even once fixed via #890), because of a bad dependency (see https://github.com/geopython/geolinks/issues/13).

When running a `docker run` on the image, you'll get this error:

```
Traceback (most recent call last):
  File "/usr/local/bin/entrypoint.py", line 52, in <module>
    from pycsw.core import admin
  File "/home/pycsw/pycsw/pycsw/core/admin.py", line 38, in <module>
    from pycsw.core import metadata, repository, util
  File "/home/pycsw/pycsw/pycsw/core/metadata.py", line 38, in <module>
    from geolinks import sniff_link
  File "/usr/local/lib/python3.8/site-packages/geolinks/__init__.py", line 34, in <module>
    import click
ModuleNotFoundError: No module named 'click'
```

This PR will add the missing dependency.

# Related Issue / Discussion

Issue [#891 Docker build of 2.6 branch will not start](https://github.com/geopython/pycsw/issues/891)

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
