### PR TITLE
safeguard JSON links in ISO mode

### DIFF
--- a/pycsw/plugins/profiles/apiso/apiso.py
+++ b/pycsw/plugins/profiles/apiso/apiso.py
@@ -688,13 +688,13 @@ class APISO(profile.Profile):
                 etree.SubElement(linkage, util.nspath_eval('gmd:URL', self.namespaces)).text = link['url']
 
                 protocol = etree.SubElement(online2, util.nspath_eval('gmd:protocol', self.namespaces))
-                etree.SubElement(protocol, util.nspath_eval('gco:CharacterString', self.namespaces)).text = link['protocol']
+                etree.SubElement(protocol, util.nspath_eval('gco:CharacterString', self.namespaces)).text = link.get('protocol', 'WWW:LINK')
 
                 name = etree.SubElement(online2, util.nspath_eval('gmd:name', self.namespaces))
-                etree.SubElement(name, util.nspath_eval('gco:CharacterString', self.namespaces)).text = link['name']
+                etree.SubElement(name, util.nspath_eval('gco:CharacterString', self.namespaces)).text = link.get('name')
 
                 desc = etree.SubElement(online2, util.nspath_eval('gmd:description', self.namespaces))
-                etree.SubElement(desc, util.nspath_eval('gco:CharacterString', self.namespaces)).text = link['description']
+                etree.SubElement(desc, util.nspath_eval('gco:CharacterString', self.namespaces)).text = link.get('description')
 
         return node
 


### PR DESCRIPTION
# Overview
Safeguards JSON links when ISO AP is used in CSW mode.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
