### PR TITLE
add conformance for q= in STAC

### DIFF
--- a/pycsw/stac/api.py
+++ b/pycsw/stac/api.py
@@ -65,7 +65,8 @@ CONFORMANCE_CLASSES = [
     'https://api.stacspec.org/v1.0.0/core',
     'https://api.stacspec.org/v1.0.0/ogcapi-features',
     'https://api.stacspec.org/v1.0.0/item-search',
-    'https://api.stacspec.org/v1.0.0/item-search#filter'
+    'https://api.stacspec.org/v1.0.0/item-search#filter',
+    'https://api.stacspec.org/v1.0.0/item-search#free-text'
 ]
 
 

--- a/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
+++ b/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
@@ -49,7 +49,7 @@ def test_landing_page(config):
 
     assert content['stac_version'] == '1.0.0'
     assert content['type'] == 'Catalog'
-    assert len(content['conformsTo']) == 14
+    assert len(content['conformsTo']) == 15
     assert len(content['keywords']) == 3
 
 
@@ -70,7 +70,7 @@ def test_conformance(config):
     assert headers['Content-Type'] == 'application/json'
     assert status == 200
 
-    assert len(content['conformsTo']) == 14
+    assert len(content['conformsTo']) == 15
 
     conformances = [
         'https://api.stacspec.org/v1.0.0/core',


### PR DESCRIPTION
# Overview
Adds STAC conformance class for `q=`
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
