### PR TITLE
OARec: add distributed search functionality

### DIFF
--- a/docs/distributedsearching.rst
+++ b/docs/distributedsearching.rst
@@ -5,17 +5,20 @@ Distributed Searching
 
 .. note::
 
-   Distributed search is supported for CSW 2/3 APIs.  OARec support will be implemented
-   following guidance from the OARec specification once available.
+   - in CSW mode, distributed search must be configured against remote CSW services
+   - in OGC API - Records mode, distributed search must be configured against remote OGC API - Records services
 
 .. note::
 
    Your server must be able to make outgoing HTTP requests for this functionality.
 
+CSW 2 / 3
+---------
+
 pycsw has the ability to perform distributed searching against other CSW servers.  Distributed searching is disabled by default; to enable, ``server.federatedcatalogues`` must be set.  A CSW client must issue a GetRecords request with ``csw:DistributedSearch`` specified, along with an optional ``hopCount`` attribute (see subclause 10.8.4.13 of the CSW specification).  When enabled, pycsw will search all specified catalogues and return a unified set of search results to the client.  Due to the distributed nature of this functionality, requests will take extra time to process compared to queries against the local repository.
 
 Scenario: Federated Search
---------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 pycsw deployment with 3 configurations (CSW-1, CSW-2, CSW-3), subsequently providing three (3) endpoints.  Each endpoint is based on an opaque metadata repository (based on theme/place/discipline, etc.).  Goal is to perform a single search against all endpoints.
  
@@ -80,3 +83,18 @@ As a result, a pycsw deployment in this scenario may be approached on a per 'the
 All interaction in this scenario is local to the pycsw installation, so network performance would not be problematic.
  
 A very important facet of distributed search is as per Annex B of OGC:CSW 2.0.2.  Given that all the CSW endpoints are managed locally, duplicates and infinite looping are not deemed to present an issue.
+
+OGC API - Records
+-----------------
+
+Experimental support for distibuted searching is available in pycsw's OGC API - Records support to allow for searching remote servers.  The implementation uses the same approach as described above, operating in OGC API - Records mode.
+
+.. code-block:: none 
+
+  [server]
+  ...
+  federatedcatalogues=https://example.org/collections/collection1,https://example.org/collections/collection2
+
+With the above configured, a distributed search can be invoked as follows:
+
+http://localhost/collections/metadata:main/items?distributed=true

--- a/docs/distributedsearching.rst
+++ b/docs/distributedsearching.rst
@@ -87,7 +87,11 @@ A very important facet of distributed search is as per Annex B of OGC:CSW 2.0.2.
 OGC API - Records
 -----------------
 
-Experimental support for distibuted searching is available in pycsw's OGC API - Records support to allow for searching remote servers.  The implementation uses the same approach as described above, operating in OGC API - Records mode.
+Experimental support for distibuted searching is available in pycsw's OGC API - Records support to allow for searching remote services.  The implementation uses the same approach as described above, operating in OGC API - Records mode.
+
+.. note::
+
+   The ``federatedcatalogues`` directives must point to an OGC API - Records **collections** endpoint.
 
 .. code-block:: none 
 

--- a/pycsw/core/util.py
+++ b/pycsw/core/util.py
@@ -534,7 +534,9 @@ def str2bool(value: typing.Union[bool, str]) -> bool:
     """
     helper function to return Python boolean
     type (source: https://stackoverflow.com/a/715468)
+
     :param value: value to be evaluated
+
     :returns: `bool` of whether the value is boolean-ish
     """
 

--- a/pycsw/ogc/api/oapi.py
+++ b/pycsw/ogc/api/oapi.py
@@ -198,6 +198,18 @@ def gen_oapi(config, oapi_filepath, mode='ogcapi-records'):
         'style': 'form',
         'explode': False
     }
+    oapi['components']['parameters']['distributed'] = {
+        'name': 'distributed',
+        'in': 'query',
+        'description': 'Whether to invoke distributed mode',
+        'schema': {
+            'type': 'boolean',
+            'default': False
+        },
+        'style': 'form',
+        'explode': False
+    }
+
     # TODO: remove local definition of ids once implemented
     # in OGC API - Records
     oapi['components']['parameters']['ids'] = {
@@ -396,8 +408,9 @@ def gen_oapi(config, oapi_filepath, mode='ogcapi-records'):
                 {'$ref': '#/components/parameters/filter-lang'},
                 {'$ref': '#/components/parameters/f'},
                 {'$ref': '#/components/parameters/offset'},
-                {'$ref': '#/components/parameters/vendorSpecificParameters'},
                 {'$ref': '#/components/parameters/facets'},
+                {'$ref': '#/components/parameters/distributed'},
+                {'$ref': '#/components/parameters/vendorSpecificParameters'}
             ],
             'responses': {
                 '200': {
@@ -467,6 +480,7 @@ def gen_oapi(config, oapi_filepath, mode='ogcapi-records'):
             'parameters': [
                 {'$ref': '#/components/parameters/collectionId'},
                 {'$ref': '#/components/parameters/recordId'},
+                {'$ref': '#/components/parameters/distributed'},
                 f
             ],
             'responses': {

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -728,13 +728,14 @@ class API:
 
         response['distributedFeatures'] = []
 
-        for fc in self.config['server']['federatedcatalogues'].split(','):
-            LOGGER.debug(f'Running distributed search against {fc}')
-            fc_url, _, fc_collection = fc.rsplit('/', 2)
-            w = Records(fc_url)
-            fc_results = w.collection_items(fc_collection, **args)
-            for feature in fc_results['features']:
-                response['distributedFeatures'].append(feature)
+        if 'federatedcatalogues' in self.config['server']:
+            for fc in self.config['server']['federatedcatalogues'].split(','):
+                LOGGER.debug(f'Running distributed search against {fc}')
+                fc_url, _, fc_collection = fc.rsplit('/', 2)
+                w = Records(fc_url)
+                fc_results = w.collection_items(fc_collection, **args)
+                for feature in fc_results['features']:
+                    response['distributedFeatures'].append(feature)
 
         LOGGER.debug('Creating links')
 
@@ -836,16 +837,17 @@ class API:
             response = record2json(record, self.config['server']['url'],
                                    collection, self.mode)
         except IndexError:
-            for fc in self.config['server']['federatedcatalogues'].split(','):
-                LOGGER.debug(f'Running distributed search against {fc}')
-                fc_url, _, fc_collection = fc.rsplit('/', 2)
-                w = Records(fc_url)
-                try:
-                    response = record = w.collection_item(fc_collection, item)
-                    LOGGER.debug(f'Found item from {fc}')
-                    break
-                except RuntimeError:
-                    continue
+            if 'federatedcatalogues' in self.config['server']:
+                for fc in self.config['server']['federatedcatalogues'].split(','):
+                    LOGGER.debug(f'Running distributed search against {fc}')
+                    fc_url, _, fc_collection = fc.rsplit('/', 2)
+                    w = Records(fc_url)
+                    try:
+                        response = record = w.collection_item(fc_collection, item)
+                        LOGGER.debug(f'Found item from {fc}')
+                        break
+                    except RuntimeError:
+                        continue
 
         if record is None:
             return self.get_exception(


### PR DESCRIPTION
# Overview
Adds initial support for distributed search by default for installations with `server.federatedcatalogues` configured:

```
[server]
...
federatedcatalogues=https://demo.pycsw.org/cite/collections/metadata:main,https://demo.pygeoapi.io/master/collections/dutch-metadata
```

Note the approach is implementation specific while this is being [discussed](https://github.com/opengeospatial/ogcapi-records/issues/118) in the OGC API - Records SWG.

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
