### PR TITLE
Fixed an error where an unused variable 'linkset' was being used for

### DIFF
--- a/pycsw/plugins/outputschemas/fgdc.py
+++ b/pycsw/plugins/outputschemas/fgdc.py
@@ -151,7 +151,7 @@ def write_record(recobj, esn, context, url=None):
     rlinks = util.getqattr(recobj, context.md_core_model['mappings']['pycsw:Links'])
     if rlinks:
         for link in util.jsonify_links(rlinks):
-            etree.SubElement(citeinfo, 'onlink', type=linkset[2]).text = link['url']
+            etree.SubElement(citeinfo, 'onlink', type=link['protocol']).text = link['url']
 
     # metd
     metainfo = etree.SubElement(node, 'metainfo')


### PR DESCRIPTION
# Overview
Fixed an error where an unused variable 'linkset' was being used for FGDC metadata (error originating from https://github.com/geopython/pycsw/commit/27ec1be8378a3110bd6076a753ed3612e44c08d7).

# Related Issue / Discussion
https://github.com/geopython/pycsw/issues/924

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute issue-924 to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
