### PR TITLE
Fixed the case when 'links' object is not loadable by JSON paackage. …

### DIFF
--- a/pycsw/plugins/outputschemas/datacite.py
+++ b/pycsw/plugins/outputschemas/datacite.py
@@ -326,7 +326,7 @@ def write_record(result, esn, context, url=None):
     rval = util.getqattr(result, context.md_core_model['mappings']['pycsw:Links'])
     if rval not in [None, '', 'null']:
         try:
-            for lnk in json.loads(rval):
+            for lnk in util.jsonify_links(rval):
                 try:
                     if lnk.get('url', '').startswith('http'):
                         ct = etree.SubElement(node, util.nspath_eval('contentUrl', NAMESPACES))


### PR DESCRIPTION
# Overview
Fixed the case when 'links' object is not loadable by JSON paackage. The utility function 'jsonify_links' is used instead of simple 'json.loads'.

# Related Issue / Discussion
https://github.com/geopython/pycsw/issues/926

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute issue-926 to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
