### PR TITLE
add self link for record items (#922)

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1257,12 +1257,21 @@ def record2json(record, url, collection, mode='ogcapi-records'):
             })
 
     record_dict['links'].append({
+        'rel': 'self',
+        'type': 'application/geo+json',
+        'title': record.identifier,
+        'name': 'item',
+        'description': record.identifier,
+        'href': f'{url}/collections/{collection}/items/{record.identifier}'
+    })
+
+    record_dict['links'].append({
         'rel': 'collection',
         'type': 'application/json',
         'title': 'Collection',
         'name': 'collection',
         'description': 'Collection',
-        'href': f"{url}/collections/{collection}"
+        'href': f'{url}/collections/{collection}'
     })
 
     if record.wkt_geometry:


### PR DESCRIPTION
# Overview
Adds `rel=self` links on `.../items` responses.

# Related Issue / Discussion
#922
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
