### PR TITLE
fix: set precision of coordinates from config

### DIFF
--- a/pycsw/core/util.py
+++ b/pycsw/core/util.py
@@ -240,11 +240,13 @@ def bbox2wktpolygon(bbox):
 
     """
 
+    precision = int(os.environ.get('COORDINATE_PRECISION', 2))
     if bbox.startswith('ENVELOPE'):
         bbox = wktenvelope2bbox(bbox)
-    minx, miny, maxx, maxy = [float(coord) for coord in bbox.split(",")]
-    return 'POLYGON((%.2f %.2f, %.2f %.2f, %.2f %.2f, %.2f %.2f, %.2f %.2f))' \
+    minx, miny, maxx, maxy = [f"{float(coord):.{precision}f}" for coord in bbox.split(",")]
+    wktGeometry = 'POLYGON((%s %s, %s %s, %s %s, %s %s, %s %s))' \
         % (minx, miny, minx, maxy, maxx, maxy, maxx, miny, minx, miny)
+    return wktGeometry
 
 
 def transform_mappings(queryables, typename):


### PR DESCRIPTION
# Overview
Fixes the issue of incorrect formatting of coordinates in the `bbox2wktpolygon` function by updating the coordinate formatting in the return statement.

# Related Issue / Discussion
Closes #53 

# Additional Information
- This change modifies the `bbox2wktpolygon` function in `pycsw/core/util.py` to use an environment variable with the desired bbox precise digits instead of `%.2f` for coordinate formatting (in case the env is not provided, the default value will be 2 as source).
- Coordinates are now restricting the number of decimal places according to client requirements.

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines