### PR TITLE
Correct misleading 'setup-repository' command in docs

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -54,7 +54,7 @@ Setting up the Database
 
 .. code-block:: bash
 
-  pycsw-admin.py setup_repository --config default.cfg
+  pycsw-admin.py setup-repository --config default.cfg
 
 This will create the necessary tables and values for the repository.
 


### PR DESCRIPTION
# Overview

For first time users this error is very frustrating, 'setup_repository' does not work.

```
Error: No such command 'setup_repository'.
```


# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [X] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
