### PR TITLE
Fixed incorrect referncing for DataCite output schema. Fixes issue#944

### DIFF
--- a/pycsw/plugins/outputschemas/datacite.py
+++ b/pycsw/plugins/outputschemas/datacite.py
@@ -241,13 +241,13 @@ def write_record(result, esn, context, url=None):
                     contnm = etree.SubElement(cont, util.nspath_eval('contributorName', NAMESPACES))
                     contnm.text = cnt.get('individualname',cnt.get('organization', ''))
                     cont.attrib['contributorType'] = roleMapping.get(cnt.get('role', ''),'Other')
-                    if cont.get('url').startswith('http'):
+                    if cnt.get('url').startswith('http'):
                         contid = etree.SubElement(cont, util.nspath_eval('nameIdentifier', NAMESPACES))
                         contid.attrib['nameIdentifierScheme'] = "URL"
-                        contid.text = cont['url']
-                    if cont['organization']:
+                        contid.text = cnt['url']
+                    if cnt['organization']:
                         contaf = etree.SubElement(cont, util.nspath_eval('affiliation', NAMESPACES))
-                        contaf.text = cont['organization']
+                        contaf.text = cnt['organization']
 
                     if not hasPublisher and cnt.get('role', '').lower() in ['publisher','resourceProvider','distributor']:
                         hasPublisher = True


### PR DESCRIPTION
# Overview
While populating the contributors for DataCite MetaData, the field "url" and "organization" is incorrectly being read from an ETree element, while it should be read from the incoming value.

# Related Issue / Discussion
https://github.com/geopython/pycsw/issues/944

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
