### PR TITLE
do not fail if fedcats is empty in config

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1021,13 +1021,12 @@ class API:
             if 'federatedcatalogues' in self.config:
                 LOGGER.debug('Adding federated catalogues')
                 collection_info['federatedCatalogues'] = []
-                if not self.config['federatedcatalogues']: # if empty in config
-                    self.config['federatedcatalogues'] = []
-                for fc in self.config.get('federatedcatalogues', []):
-                    collection_info['federatedCatalogues'].append({
-                        'type': 'OGC API - Records',
-                        'url': fc
-                    })
+                if self.config.get('federatedcatalogues') not in [None,""]: # if empty in config
+                    for fc in self.config.get('federatedcatalogues'):
+                        collection_info['federatedCatalogues'].append({
+                            'type': 'OGC API - Records',
+                            'url': fc
+                        })
 
         return collection_info
 

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1021,6 +1021,8 @@ class API:
             if 'federatedcatalogues' in self.config:
                 LOGGER.debug('Adding federated catalogues')
                 collection_info['federatedCatalogues'] = []
+                if not self.config['federatedcatalogues']: # if empty in config
+                    self.config['federatedcatalogues'] = []
                 for fc in self.config.get('federatedcatalogues', []):
                     collection_info['federatedCatalogues'].append({
                         'type': 'OGC API - Records',

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1021,7 +1021,7 @@ class API:
             if 'federatedcatalogues' in self.config:
                 LOGGER.debug('Adding federated catalogues')
                 collection_info['federatedCatalogues'] = []
-                if self.config.get('federatedcatalogues') not in [None,""]: # if empty in config
+                if self.config.get('federatedcatalogues') not in [None, '']:  # if empty in config
                     for fc in self.config.get('federatedcatalogues'):
                         collection_info['federatedCatalogues'].append({
                             'type': 'OGC API - Records',


### PR DESCRIPTION
# Overview

in python, if foo['bar'] is None:
```
foo.get('bar',[]) == None
```
therefore add a None check, before calling it, probable there is a more efficient way to do it...

# Related Issue / Discussion

#947 

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
