### PR TITLE
make sure postalcode is a string

### DIFF
--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -259,7 +259,7 @@ class Csw3(object):
             etree.SubElement(address,
             util.nspath_eval('ows20:PostalCode',
             self.parent.context.namespaces)).text = \
-            metadata_main['contact'].get('postalcode', 'missing')
+            str(metadata_main['contact'].get('postalcode', 'missing'))
 
             etree.SubElement(address,
             util.nspath_eval('ows20:Country', self.parent.context.namespaces)).text = \


### PR DESCRIPTION
# Overview

make sure postalcode in config is a string, else csw capabilities fails

# Related Issue / Discussion

#951

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
