### PR TITLE
formats as list

### DIFF
--- a/pycsw/ogc/api/templates/item.html
+++ b/pycsw/ogc/api/templates/item.html
@@ -42,8 +42,8 @@
           {% if 'properties' in data %}
             {% for key, value in data['properties'].items() %}
             <tr>
-              <td>{{ key }}</td>
-              {% if key == 'keywords' %}
+              <td>{{ key | capitalize }}</td>
+              {% if key == 'keywords' or key == 'formats' %}
                 <td>
                   <ul>
                   {% for keyword in value %}
@@ -114,7 +114,17 @@
           {% if data['time'] %}
           <tr>
             <td>Temporal</td>
-            <td>{{ data['time'] }}</td>
+            <td>
+              <ul>
+                {% if data['time'] is string  %}
+                  <li>{{ data['time'] }}</li>
+                {% else %}
+                  {% for d in data['time'] %}
+                    <li>{{ d }}</li>
+                  {% endfor %}
+                {% endif %}
+              </ul>
+            </td>
           </tr>
           {% endif %}
           <tr>


### PR DESCRIPTION
# Overview

some item properties are printed as array, should be list

![image](https://github.com/geopython/pycsw/assets/299829/618a8584-f699-447c-bd6d-bd0b4d6f50e6)

Seems the time property sometimes is string, sometimes list. so adding a type-check to handle both cases, we could also add the type check for the general case...

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
