### PR TITLE
proposal to move title/abstract from item-table to page header

### DIFF
--- a/pycsw/ogc/api/templates/item.html
+++ b/pycsw/ogc/api/templates/item.html
@@ -1,5 +1,5 @@
 {% extends "_base.html" %}
-{% block title %}{{ super() }} {{ data['id'] }} {% endblock %}
+{% block title %}{{ data.get('properties',{}).get('title',data['id']) }} - {{ super() }}{% endblock %}
 {% block extrahead %}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
     <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
@@ -22,11 +22,16 @@
 {% block body %}
 
 <section id="item">
-
-<h2>{{ data['id'] }}</h2>
-
 <div class="container-fluid">
-  <div class="row">
+  <div class="row pb-3">
+    <div class="col-lg-12">
+      <small>{{ data.get('properties',{}).get('type','') | capitalize }}</small>
+      <h2>{{ data.get('properties',{}).get('title',data['id']) }}</h2>
+      <p>{{ data.get('properties',{}).get('description','') }}</p>
+    </div>
+  </div>
+
+  <div class="row pb-5">
     <div class="col-lg-6">
       <div id="records-map"></div>
     </div>
@@ -41,76 +46,77 @@
         <tbody>
           {% if 'properties' in data %}
             {% for key, value in data['properties'].items() %}
-            <tr>
-              <td>{{ key | capitalize }}</td>
-              {% if key == 'keywords' or key == 'formats' %}
-                <td>
-                  <ul>
-                  {% for keyword in value %}
-                    <li>{{ keyword }}</li>
-                  {% endfor %}
-                  </ul>
-                </td>
-
-              {% elif key == 'themes' %}
-                <td>
-                {% for theme in value %}
-                  <b>{{ theme['scheme'] }}</b>
-                  <ul>
-                  {% for concept in theme['concepts'] %}
-                    <li>
-                      {% if concept['url'] %}
-                        <a href="{{ concept['url'] }}">{{ concept['name'] or concept['url'] }}</a>
-                      {% else %}
-                        {{ concept['name'] }}
-                      {% endif %}
-                    </li>
-                  {% endfor %}
-                  </ul>
-                {% endfor %}
-                </td>
-              {% elif key == 'externalIds' %}
-                <td>
-                  <ul>
-                    {% for id in value %}
-                    <li>{{ id['scheme'] | urlize }} {{ id['value'] | urlize }}</li>
+              {% if key not in ['title', 'description', 'type'] %}
+              <tr>
+                <td>{{ key | capitalize }}</td>
+                {% if key == 'keywords' or key == 'formats' %}
+                  <td>
+                    <ul>
+                    {% for keyword in value %}
+                      <li>{{ keyword }}</li>
                     {% endfor %}
-                  </ul>
-                </td>
-              {% elif key == 'providers' %}
-                <td>
-                  {% for cnt in data['properties']['providers'] %}
-                    {% if 'name' in cnt and cnt['name'] not in [None,''] %}
-                      {{ cnt['name'] }} <br/>
-                    {% endif %}
-                    {% if 'roles' in cnt and cnt['roles'] is not string %}
-                    Role: {{ cnt['roles'] | map(attribute='name') | join(',') }} <br/>
-                    {% endif %}
-                    {% if 'positionName' in cnt and cnt['positionName'] not in [None,''] %}
-                    Position: {{ cnt['positionName'] }})<br/>
-                    {% endif %}
-                    {% if 'contactInfo' in cnt and cnt['contactInfo'] is not string %}
-                      {% for k,e in cnt['contactInfo'].get('phone',{}).items() %}
-                        {% if e %}{{ k }}: {{ e }}<br/>{% endif %}
-                      {% endfor %}
-                      {% for k,e in cnt['contactInfo'].get('email',{}).items() %}
-                        {% if e not in [None,''] %}{{ k }}: {{ e | urlize }}<br/>{% endif %}
-                      {% endfor %}
-                      {% for k,e in cnt['contactInfo'].get('address',{}).items() %}
-                        {{ k }}: {% for a,b in e.items() %}{% if b %}{{ b }}, {% endif %}{% endfor %}<br/>
-                      {% endfor %}
-                      {% if cnt['contactInfo']['url'] %}
-                        {{ cnt['contactInfo']['url'].get('href','') | urlize }}
-                      {% endif %}
-                    {% endif %}
+                    </ul>
+                  </td>
+                {% elif key == 'themes' %}
+                  <td>
+                  {% for theme in value %}
+                    <b>{{ theme['scheme'] }}</b>
+                    <ul>
+                    {% for concept in theme['concepts'] %}
+                      <li>
+                        {% if concept['url'] %}
+                          <a href="{{ concept['url'] }}">{{ concept['name'] or concept['url'] }}</a>
+                        {% else %}
+                          {{ concept['name'] }}
+                        {% endif %}
+                      </li>
+                    {% endfor %}
+                    </ul>
                   {% endfor %}
-                </td>
-              {% else %}
-                <td>{{ value }}</td>
+                  </td>
+                {% elif key == 'externalIds' %}
+                  <td>
+                    <ul>
+                      {% for id in value %}
+                      <li>{{ id['scheme'] | urlize }} {{ id['value'] | urlize }}</li>
+                      {% endfor %}
+                    </ul>
+                  </td>
+                {% elif key == 'providers' %}
+                  <td>
+                    {% for cnt in data['properties']['providers'] %}
+                      {% if 'name' in cnt and cnt['name'] not in [None,''] %}
+                        {{ cnt['name'] }} <br/>
+                      {% endif %}
+                      {% if 'roles' in cnt and cnt['roles'] is not string %}
+                      Role: {{ cnt['roles'] | map(attribute='name') | join(',') }} <br/>
+                      {% endif %}
+                      {% if 'positionName' in cnt and cnt['positionName'] not in [None,''] %}
+                      Position: {{ cnt['positionName'] }})<br/>
+                      {% endif %}
+                      {% if 'contactInfo' in cnt and cnt['contactInfo'] is not string %}
+                        {% for k,e in cnt['contactInfo'].get('phone',{}).items() %}
+                          {% if e %}{{ k }}: {{ e }}<br/>{% endif %}
+                        {% endfor %}
+                        {% for k,e in cnt['contactInfo'].get('email',{}).items() %}
+                          {% if e not in [None,''] %}{{ k }}: {{ e | urlize }}<br/>{% endif %}
+                        {% endfor %}
+                        {% for k,e in cnt['contactInfo'].get('address',{}).items() %}
+                          {{ k }}: {% for a,b in e.items() %}{% if b %}{{ b }}, {% endif %}{% endfor %}<br/>
+                        {% endfor %}
+                        {% if cnt['contactInfo']['url'] %}
+                          {{ cnt['contactInfo']['url'].get('href','') | urlize }}
+                        {% endif %}
+                      {% endif %}
+                    {% endfor %}
+                  </td>
+                {% else %}
+                  <td>{{ value }}</td>
+                {% endif %}
+              </tr>
               {% endif %}
-            </tr>
             {% endfor %}
-          {% endif%}
+          {% endif %}
           {% if data['time'] %}
           <tr>
             <td>Temporal</td>

--- a/pycsw/ogc/api/templates/item.html
+++ b/pycsw/ogc/api/templates/item.html
@@ -25,9 +25,9 @@
 <div class="container-fluid">
   <div class="row pb-3">
     <div class="col-lg-12">
-      <small>{{ data.get('properties',{}).get('type','') | capitalize }}</small>
+      <small class="text-primary fw-bold">{{ (data.get('properties',{}).get('type') or '').split('/').pop() | capitalize }}</small>
       <h2>{{ data.get('properties',{}).get('title',data['id']) }}</h2>
-      <p>{{ data.get('properties',{}).get('description','') }}</p>
+      <p>{{ data.get('properties',{}).get('description','') | urlize }}</p>
     </div>
   </div>
 
@@ -46,7 +46,6 @@
         <tbody>
           {% if 'properties' in data %}
             {% for key, value in data['properties'].items() %}
-              {% if key not in ['title', 'description', 'type'] %}
               <tr>
                 <td>{{ key | capitalize }}</td>
                 {% if key == 'keywords' or key == 'formats' %}
@@ -111,10 +110,13 @@
                     {% endfor %}
                   </td>
                 {% else %}
-                  <td>{{ value }}</td>
+                  {% if key in ['title','description'] %}
+                    <td>{{ value | truncate(80, False, '...') }}</td>
+                  {% else %}
+                    <td>{{ value | urlize }}</td>
+                  {% endif %}
                 {% endif %}
               </tr>
-              {% endif %}
             {% endfor %}
           {% endif %}
           {% if data['time'] %}


### PR DESCRIPTION
# Overview

this moves the type, title and abstract properties from the table to the header of the html representation for readability

![image](https://github.com/geopython/pycsw/assets/299829/263a4ae0-9173-4b70-a97a-e2616dcba3c8)

It also uses the item title on html-head-title 

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
