### PR TITLE
set resumptionToken as empty for completed result sets

### DIFF
--- a/pycsw/oaipmh.py
+++ b/pycsw/oaipmh.py
@@ -274,7 +274,11 @@ class OAIPMH(object):
                     cursor = str(int(complete_list_size) - int(next_record) - 1)
 
                     resumption_token = etree.SubElement(verbnode, util.nspath_eval('oai:resumptionToken', self.namespaces),
-                                                        completeListSize=complete_list_size, cursor=cursor).text = next_record
+                                                        completeListSize=complete_list_size, cursor=cursor)
+
+                    if int(next_record) > 0:
+                        resumption_token.text = next_record
+
         return node
 
     def _get_metadata_prefix(self, prefix):


### PR DESCRIPTION
# Overview
Sets OAI-PMH ListRecords `resumptionToken` to empty if at the end of a result set.

# Related Issue / Discussion
None
# Additional Information
As per http://www.openarchives.org/OAI/openarchivesprotocol.html#FlowControl (thanks @steingod)

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
