### PR TITLE
remove usage of old mock

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,11 +40,7 @@
 # serve to show the default.
 
 import sys, os
-
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import Mock as MagicMock
+from unittest.mock import MagicMock
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/requirements-mocked.txt
+++ b/docs/requirements-mocked.txt
@@ -1,5 +1,4 @@
 # This file holds some fake requirements to fool the readthedocs service into
 # building the documentation. For more information, see
 # https://github.com/geopython/pycsw/issues/521
-mock
 sphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@
 -r requirements-standalone.txt
 
 apipkg==1.4
-mock==2.0.0
 Paver==1.2.4
 pytest==6.2.4
 pytest-cov==2.12.0

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -32,8 +32,8 @@ import datetime as dt
 import os
 import time
 from pathlib import Path
+from unittest import mock
 
-import mock
 import pytest
 from shapely.wkt import loads
 

--- a/tests/unittests/test_wsgi.py
+++ b/tests/unittests/test_wsgi.py
@@ -30,9 +30,10 @@
 # =================================================================
 """Unit tests for pycsw.wsgi"""
 
+import unittest import mock
+
 from wsgiref.util import setup_testing_defaults
 
-import mock
 import pytest
 
 from pycsw import wsgi

--- a/tests/unittests/test_wsgi.py
+++ b/tests/unittests/test_wsgi.py
@@ -30,7 +30,7 @@
 # =================================================================
 """Unit tests for pycsw.wsgi"""
 
-import unittest import mock
+from unittest import mock
 
 from wsgiref.util import setup_testing_defaults
 

--- a/tests/unittests/test_wsgi.py
+++ b/tests/unittests/test_wsgi.py
@@ -31,7 +31,6 @@
 """Unit tests for pycsw.wsgi"""
 
 from unittest import mock
-
 from wsgiref.util import setup_testing_defaults
 
 import pytest


### PR DESCRIPTION
https://github.com/testing-cabal/mock

"mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards."

 I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.

