### PR TITLE
update to Shapely 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ lxml
 OWSLib
 pyproj
 PyYAML
-Shapely<2.0
+Shapely
 xmltodict


### PR DESCRIPTION
# Overview
This PR updates Shapely support to version 2.x.
# Related Issue / Discussion
#970
# Additional Information
Note that Shapely uses Numpy, which may affect the size of resulting installations/images.
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines