### PR TITLE
reset pagination at filter change

### DIFF
--- a/pycsw/ogc/api/templates/items.html
+++ b/pycsw/ogc/api/templates/items.html
@@ -50,11 +50,14 @@
 {% endif %}
 
 {# update existing url with new key,val. indent prevents spaces in output #}
+{# reset pagination, else you may end up in empty result #}
 {% macro updateurl(key=None,val=None) %}{{ nav_links.self.split('?')[0] }}?{% 
-  for at in attrs.keys() %}{% 
-    if attrs[at] not in [None,''] %}{% 
-      if key not in [None,''] and key == at %}&{{ at }}={{ val }}{% 
-      else %}&{{ at }}={{ attrs[at] }}{% 
+  for at in attrs.keys() %}{%
+    if at != 'offset' %}{%
+      if attrs[at] not in [None,''] %}{% 
+        if key not in [None,''] and key == at %}&{{ at }}={{ val }}{% 
+        else %}&{{ at }}={{ attrs[at] }}{% 
+        endif %}{% 
       endif %}{% 
     endif %}{%
     if key not in attrs.keys() %}&{{ key }}={{ val }}{% endif %}{% 
@@ -100,7 +103,7 @@ endmacro %}
           </div>
           <div>
             {% if 'facets=true' in nav_links.self %}
-            <a href="#" onclick="{{ reseturl() }}">Reset</a>
+            <a href="{{ reseturl() }}">Reset</a>
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
# Overview

reset pagination if a filter is applied, so you don't end up in an empty search result (when filtering from page >1)

also fixes reseturl

# Related Issue / Discussion

#969

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
