### PR TITLE
set GetRecords results returned to 0 when resulttype = hits

### DIFF
--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -908,7 +908,7 @@ class Csw2(object):
         self.parent.context.namespaces), timestamp=timestamp)
 
         if 'where' not in self.parent.kvp['constraint'] and \
-        self.parent.kvp['resulttype'] is None:
+        self.parent.kvp['resulttype'] in [None, 'hits']:
             returned = '0'
 
         searchresults = etree.SubElement(node,

--- a/tests/functionaltests/suites/default/expected/get_GetRecords-all.xml
+++ b/tests/functionaltests/suites/default/expected/get_GetRecords-all.xml
@@ -2,5 +2,5 @@
 <!-- PYCSW_VERSION -->
 <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:gml32="http://www.opengis.net/gml/3.2" xmlns:ows="http://www.opengis.net/ows" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.2" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
   <csw:SearchStatus timestamp="PYCSW_TIMESTAMP"/>
-  <csw:SearchResults numberOfRecordsMatched="12" numberOfRecordsReturned="10" nextRecord="11" recordSchema="http://www.opengis.net/cat/csw/2.0.2" elementSet="full"/>
+  <csw:SearchResults numberOfRecordsMatched="12" numberOfRecordsReturned="0" nextRecord="11" recordSchema="http://www.opengis.net/cat/csw/2.0.2" elementSet="full"/>
 </csw:GetRecordsResponse>

--- a/tests/functionaltests/suites/default/expected/get_GetRecords-empty-maxrecords.xml
+++ b/tests/functionaltests/suites/default/expected/get_GetRecords-empty-maxrecords.xml
@@ -2,5 +2,5 @@
 <!-- PYCSW_VERSION -->
 <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:gml32="http://www.opengis.net/gml/3.2" xmlns:ows="http://www.opengis.net/ows" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.2" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
   <csw:SearchStatus timestamp="PYCSW_TIMESTAMP"/>
-  <csw:SearchResults numberOfRecordsMatched="12" numberOfRecordsReturned="10" nextRecord="11" recordSchema="http://www.opengis.net/cat/csw/2.0.2" elementSet="full"/>
+  <csw:SearchResults numberOfRecordsMatched="12" numberOfRecordsReturned="0" nextRecord="11" recordSchema="http://www.opengis.net/cat/csw/2.0.2" elementSet="full"/>
 </csw:GetRecordsResponse>

--- a/tests/functionaltests/suites/default/expected/post_GetRecords-all-resulttype-hits.xml
+++ b/tests/functionaltests/suites/default/expected/post_GetRecords-all-resulttype-hits.xml
@@ -2,5 +2,5 @@
 <!-- PYCSW_VERSION -->
 <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:gml32="http://www.opengis.net/gml/3.2" xmlns:ows="http://www.opengis.net/ows" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.2" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
   <csw:SearchStatus timestamp="PYCSW_TIMESTAMP"/>
-  <csw:SearchResults numberOfRecordsMatched="12" numberOfRecordsReturned="5" nextRecord="6" recordSchema="http://www.opengis.net/cat/csw/2.0.2" elementSet="full"/>
+  <csw:SearchResults numberOfRecordsMatched="12" numberOfRecordsReturned="0" nextRecord="6" recordSchema="http://www.opengis.net/cat/csw/2.0.2" elementSet="full"/>
 </csw:GetRecordsResponse>


### PR DESCRIPTION
# Overview
set GetRecords `//@numberOfRecordsReturned` to 0 when resulttype = hits
# Related Issue / Discussion

# Additional Information
Note that the fix has been tested against OGC CITE for CSW 2.0.2 and CSW 3.0.0 (note that in CSW 3.0.0 `GetRecords.resulttype` was removed and made available in `GetDomain` with different semantics).

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
