### PR TITLE
[WIP] fail when repository cannot init

### DIFF
--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -425,8 +425,8 @@ class Csw(object):
                     except:
                         LOGGER.debug(f'Repository not loaded retry connection {max_attempts}')
                         max_attempts += 1
-                if not connection_done:
-                    raise
+                        if max_attempts == self.max_retries:
+                            raise
             except Exception as err:
                 msg = 'Could not load repository (local): %s' % err
                 LOGGER.exception(msg)

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -424,7 +424,9 @@ class Csw(object):
                         connection_done = True
                     except:
                         LOGGER.debug(f'Repository not loaded retry connection {max_attempts}')
+                        LOGGER.debug(f"{self.config['repository']['database']}")
                         max_attempts += 1
+                        raise
             except Exception as err:
                 msg = 'Could not load repository (local): %s' % err
                 LOGGER.exception(msg)

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -424,9 +424,9 @@ class Csw(object):
                         connection_done = True
                     except:
                         LOGGER.debug(f'Repository not loaded retry connection {max_attempts}')
-                        LOGGER.debug(f"{self.config['repository']['database']}")
                         max_attempts += 1
-                        raise
+                if not connection_done:
+                    raise
             except Exception as err:
                 msg = 'Could not load repository (local): %s' % err
                 LOGGER.exception(msg)


### PR DESCRIPTION
# Overview
This PR causes pycsw to fail on repository initialization if a connection cannot be made to the underlying metadata repository (current behaviour fails silently on repository init, and provides misleading error on subsequent interactions with `self.repository`).

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
