### PR TITLE
fix CSW 2/3 distributed search hopcount handling

### DIFF
--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -1736,7 +1736,7 @@ class Csw2(object):
             if tmp is not None:
                 request['distributedsearch'] = True
                 hopcount = tmp.attrib.get('hopCount')
-                request['hopcount'] = int(hopcount)-1 if hopcount is not None \
+                request['hopcount'] = int(hopcount) if hopcount is not None \
                 else 2
             else:
                 request['distributedsearch'] = False

--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -823,7 +823,7 @@ class Csw2(object):
 
         dsresults = []
 
-        hopcount = int(self.parent.kvp.get('hopcount', 2))
+        hopcount = int(self.parent.kvp.get('hopcount', 2)) - 1
 
         if ('federatedcatalogues' in self.parent.config and
                 self.parent.kvp.get('distributedsearch') and

--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -823,13 +823,13 @@ class Csw2(object):
 
         dsresults = []
 
-        if ('federatedcatalogues' in self.parent.config and
-            'distributedsearch' in self.parent.kvp and 'hopcount' in self.parent.kvp and
-            self.parent.kvp['distributedsearch'] and int(self.parent.kvp['hopcount']) > 0):
-            # do distributed search
+        hopcount = int(self.parent.kvp.get('hopcount', 2))
 
-            LOGGER.debug('DistributedSearch specified (hopCount: %s).',
-            self.parent.kvp['hopcount'])
+        if ('federatedcatalogues' in self.parent.config and
+                self.parent.kvp.get('distributedsearch') and
+                hopcount > 0):
+
+            LOGGER.debug('DistributedSearch specified (hopCount: %s).', hopcount)
 
             from owslib.csw import CatalogueServiceWeb
             from owslib.ows import ExceptionReport
@@ -1737,7 +1737,7 @@ class Csw2(object):
                 request['distributedsearch'] = True
                 hopcount = tmp.attrib.get('hopCount')
                 request['hopcount'] = int(hopcount)-1 if hopcount is not None \
-                else 1
+                else 2
             else:
                 request['distributedsearch'] = False
 

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -972,7 +972,7 @@ class Csw3(object):
                         'Record serialization failed: %s' % str(err))
                         return self.parent.response
 
-        hopcount = int(self.parent.kvp.get('hopcount', 2))
+        hopcount = int(self.parent.kvp.get('hopcount', 2)) - 1
 
         if ('federatedcatalogues' in self.parent.config and
                 self.parent.kvp.get('distributedsearch') and

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -1806,8 +1806,8 @@ class Csw3(object):
             if tmp is not None:
                 request['distributedsearch'] = True
                 hopcount = tmp.attrib.get('hopCount')
-                request['hopcount'] = int(hopcount)-1 if hopcount is not None \
-                else 1
+                request['hopcount'] = int(hopcount) if hopcount is not None \
+                else 2
             else:
                 request['distributedsearch'] = False
 

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -972,19 +972,13 @@ class Csw3(object):
                         'Record serialization failed: %s' % str(err))
                         return self.parent.response
 
+        hopcount = int(self.parent.kvp.get('hopcount', 2))
+
         if ('federatedcatalogues' in self.parent.config and
-            'distributedsearch' in self.parent.kvp and 'hopcount' in self.parent.kvp and
-            self.parent.kvp['distributedsearch'] and int(self.parent.kvp['hopcount']) > 0):
-            # do distributed search
+                self.parent.kvp.get('distributedsearch') and
+                hopcount > 0):
 
-#        if all(['federatedcatalogues' in self.parent.config,
-#                'distributedsearch' in self.parent.kvp,
-#                self.parent.kvp['distributedsearch'],
-#                'hopcount' in self.parent.kvp,
-#                int(self.parent.kvp['hopcount']) > 0]):  # do distributed search
-
-            LOGGER.debug('DistributedSearch specified (hopCount: %s)',
-            self.parent.kvp['hopcount'])
+            LOGGER.debug('DistributedSearch specified (hopCount: %s).', hopcount)
 
             from owslib.csw import CatalogueServiceWeb
             from owslib.ows import ExceptionReport


### PR DESCRIPTION
# Overview
Fixes CSW 2/3 DistributedSearch `hopcount` handling (does not propagate if decremented `hopcount=0`) as per CSW 2.0.2 Subclause 10.8.4.13 / CSW 3.0.0 Subclause 7.3.4.12.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
