### PR TITLE
adds the contactinfo from dedicated role fields

### DIFF
--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1651,6 +1651,8 @@ def _parse_dc(context, repos, exml):
 
     md = CswRecord(exml)
 
+    print(md)
+
     if md.bbox is None:
         bbox = None
     else:

--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1651,8 +1651,6 @@ def _parse_dc(context, repos, exml):
 
     md = CswRecord(exml)
 
-    print(md)
-
     if md.bbox is None:
         bbox = None
     else:

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1196,9 +1196,11 @@ def record2json(record, url, collection, mode='ogcapi-records'):
 
     if record.contacts not in [None, '', 'null']:
         rcnt = []
+        roles = [] 
         try:
             for cnt in json.loads(record.contacts):
                 try:
+                    roles.append(cnt.get('role', '').lower())
                     rcnt.append({
                         'name': cnt['name'],
                         'organization': cnt.get('organization', ''),
@@ -1223,6 +1225,13 @@ def record2json(record, url, collection, mode='ogcapi-records'):
                     })
                 except Exception as err:
                     LOGGER.exception(f"failed to parse contact of {record.identifier}: {err}")
+            for r2 in "creator,publisher,contributor".split(","): # match role-fields with contacts
+                if r2 not in roles and hasattr(record,r2) and record[r2] not in [None,'']:
+                    rcnt.append({
+                        'organization': record[r2],
+                        'roles': [r2]
+                    })
+
         except Exception as err:
             LOGGER.exception(f"failed to parse contacts json of {record.identifier}: {err}")
 


### PR DESCRIPTION
adds the contactinfo from dedicated role fields, if the role does not…already exists in contacts

# Overview

the ogcapi- records json fully depends on record.contacts, however in some cases records.contacts is not populated (for example from dublin core), then fall back to the explicit role fields 'creator', 'publisher', 'contributor'. 



(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
