### PR TITLE
[records] splits formats by `,` 

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1181,7 +1181,7 @@ def record2json(record, url, collection, mode='ogcapi-records'):
         record_dict['properties']['description'] = record.abstract
 
     if record.format:
-        record_dict['properties']['formats'] = [{'name': record.format}]
+        record_dict['properties']['formats'] = [{'name': f} for f in record.format.split(',') if len(f) > 1]
 
     if record.keywords:
         record_dict['properties']['keywords'] = [x for x in record.keywords.split(',')]

--- a/pycsw/ogc/api/templates/item.html
+++ b/pycsw/ogc/api/templates/item.html
@@ -48,11 +48,19 @@
             {% for key, value in data['properties'].items() %}
               <tr>
                 <td>{{ key | capitalize }}</td>
-                {% if key == 'keywords' or key == 'formats' %}
+                {% if key == 'keywords' %}
                   <td>
                     <ul>
                     {% for keyword in value %}
                       <li>{{ keyword }}</li>
+                    {% endfor %}
+                    </ul>
+                  </td>
+                {% elif key == 'formats' %}
+                  <td>
+                    <ul>
+                    {% for f in value %}
+                      <li>{{ f.get('name') }}</li>
                     {% endfor %}
                     </ul>
                   </td>


### PR DESCRIPTION


# Overview

splits formats by `,` and improve display

# Related Issue / Discussion

resolves #1011


# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
