### PR TITLE
None check k.name; iso import

### DIFF
--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1448,12 +1448,12 @@ def _parse_iso(context, repos, exml):
         if (hasattr(md_identification, 'keywords') and
             len(md_identification.keywords) > 0):
             all_keywords = [item for sublist in md_identification.keywords for item in sublist.keywords if item is not None]
-            if all_keywords:
-                _set(context, recobj, 'pycsw:Keywords', ','.join([k.name for k in all_keywords if hasattr(k,'name')]))
-                _set(context, recobj, 'pycsw:KeywordType', md_identification.keywords[0].type)
-                _set(context, recobj, 'pycsw:Themes', 
-                    json.dumps([t for t in md_identification.keywords if t.thesaurus is not None], 
-                                default=lambda o: o.__dict__))
+            _set(context, recobj, 'pycsw:Keywords', ','.join([
+                k.name for k in all_keywords if hasattr(k,'name') and k.name not in [None,'']]))
+            _set(context, recobj, 'pycsw:KeywordType', md_identification.keywords[0].type)
+            _set(context, recobj, 'pycsw:Themes', 
+                json.dumps([t for t in md_identification.keywords if t.thesaurus is not None], 
+                            default=lambda o: o.__dict__))
 
         # Creator
         if (hasattr(md_identification, 'creator') and


### PR DESCRIPTION
# Overview

previous fix unfortunately did not solve the issue,
the issue was not related to all-keywords being empty, but inside the keywords array, keyword.name being None.
this PR removes the None check for all-keywords, and adds None check for k.name

reproduce error by:

```python
','.join(['a',None,'b'])
```

# Related Issue / Discussion

#1019

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
