### PR TITLE
a spatial filter for UI

### DIFF
--- a/pycsw/ogc/api/templates/items.html
+++ b/pycsw/ogc/api/templates/items.html
@@ -3,8 +3,11 @@
 
 {% block extrahead %}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css"></script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
     <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
     <style>
         #records-map {
             height: 350px;
@@ -95,7 +98,14 @@ endmacro %}
           <b>{{ data['numberMatched'] }} results.</b>
       </div>
       <div id="records-map"></div>
-      <div id="facets" class="pt-3">
+      <div id="spatial-filter" class="mt-2">
+        <div class="form-check form-switch">
+          <input class="form-check-input my-2" onchange="trigger_spatial_filter()" {% if 'bbox' in attrs.keys() %}checked{% endif %} type="checkbox" id="spatial-filter-check">
+          <label class="form-check-label" for="spatial-filter-check">Spatial filter</label>
+          <btn class="btn btn-sm border border-rounded" onclick="apply_spatial_filter()">Apply</btn>
+        </div>  
+      </div>
+      <div id="facets" class="mt-2">
         <div class="d-flex justify-content-between">
           <div class="form-check form-switch">
             <input class="form-check-input" type="checkbox" {% if 'facets=true' in nav_links.self %}checked="true"{% endif %} onchange="facet(this.checked)"  role="switch" id="enableFacets">
@@ -201,13 +211,26 @@ function sort(val){
 function facet(val){
   location.href="{{updateurl('facets','facetprop')}}".replace('facetprop',val);
 }
+{% if 'bbox' in attrs.keys() and (attrs['bbox'].split('%2C')|length) == 4 %}
+var bbox = [
+          [{{ attrs['bbox'].split('%2C')[1] }}, {{ attrs['bbox'].split('%2C')[0] }}], 
+          [{{ attrs['bbox'].split('%2C')[3] }}, {{ attrs['bbox'].split('%2C')[2] }}]
+        ]
+{% else %}
+var bbox = null;
+{% endif %}
+function apply_spatial_filter(){
+  if ($('#spatial-filter-check').attr('checked')) {
+    location.href="{{ updateurl('bbox','tmptmp') }}".replace('tmptmp',yx(rectangle.getBounds()));
+  }
+}
 </script>
 
 {% endblock %}
 
 {% block extrafoot %}
-{% if data['features'] %}
-    <script>
+
+<script>
     var map = L.map('records-map').setView([0, 0], 1);
     map.addLayer(new L.TileLayer(
         'https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -216,6 +239,7 @@ function facet(val){
         }
     ));
     var geojson_data = {{ data['features'] | to_json }};
+    {% if data['features'] %}
     var items = new L.GeoJSON(geojson_data, {
         onEachFeature: function (feature, layer) {
             var url = './items/' + feature.id;
@@ -226,17 +250,25 @@ function facet(val){
     });
 
     map.addLayer(items);
-    var bounds = items.getBounds();
-    if (bounds.isValid() === true) {
-        map.fitBounds(bounds);
+    if (!bbox){
+      var bounds = items.getBounds();
+      if (bounds.isValid() === true) {
+          map.fitBounds(bounds);
+      }
     }
+    {% endif %}
+    
+    if (bbox){
+      setRectangle(bbox);
+      map.fitBounds(bbox);
+    } 
 
     var highlightStyle = {
         color: 'red',
         dashArray: '',
         fillOpacity: 0.5
     }
-
+    {% if data['features'] %}
     $(document).ready(function() {
         $('#items-table-table tr').on('mouseenter', function(e){
             id_ = $(this).find('[id]').attr('id');
@@ -252,7 +284,6 @@ function facet(val){
         $("#q").on("keypress", function(event){
             if (event.which == 13 && !event.shiftKey) {
                 event.preventDefault();
-
                 var queryParams = new URLSearchParams(window.location.search);
                 queryParams.set("q", $("#q").val());
                 var new_url = '{{ config['server']['url'] }}/collections/{{ data['collection'] }}/items?' + queryParams.toString();
@@ -260,6 +291,41 @@ function facet(val){
             }
         });
     });
-    </script>
-{% endif %}
+    {% endif %}
+
+function yx (b){
+  if (b && b._southWest){
+    return [b._southWest.lng,b._southWest.lat,b._northEast.lng,b._northEast.lat].join(',');
+  }
+}
+
+var rectangle;
+
+function setRectangle(bbox){
+  if (rectangle){
+      rectangle.setBounds(bbox)
+  } else {
+      rectangle = L.rectangle(bbox);
+      rectangle.editing.enable();
+      rectangle.on('edit', function() {
+        bbox = rectangle.getBounds();
+        console.log(rectangle.getBounds().toString());
+      });
+  }
+  map.addLayer(rectangle);
+}
+
+function trigger_spatial_filter(){
+    if (map.hasLayer(rectangle)){
+      console.log(bbox);
+      rectangle.remove();
+      bbox = null;
+    } else {
+      console.log(map.getBounds().pad(-0.95));
+      setRectangle(map.getBounds().pad(-0.95));
+    }
+}
+  
+</script>
+
 {% endblock %}

--- a/pycsw/ogc/api/templates/items.html
+++ b/pycsw/ogc/api/templates/items.html
@@ -211,14 +211,16 @@ function sort(val){
 function facet(val){
   location.href="{{updateurl('facets','facetprop')}}".replace('facetprop',val);
 }
+
 //if url has a bbox, enable the spatial filter 
-{% if 'bbox' in attrs.keys() and (attrs['bbox'].split('%2C')|length) == 4 %}
-var bbox = [
-          [{{ attrs['bbox'].split('%2C')[1] }}, {{ attrs['bbox'].split('%2C')[0] }}], 
-          [{{ attrs['bbox'].split('%2C')[3] }}, {{ attrs['bbox'].split('%2C')[2] }}]
-        ]
-{% else %}
-var bbox = null;
+var bbox;
+{% if 'bbox' in attrs.keys() %}
+  {% set bbox_tokens = attrs['bbox'].split('%2C') %}
+  {% if bbox_tokens|length == 4 %}
+    bbox = [[{{ 
+      bbox_tokens[1] }}, {{ bbox_tokens[0] }}], [{{ 
+      bbox_tokens[3] }}, {{ bbox_tokens[2] }}]];
+  {% endif %}
 {% endif %}
 
 //if filter enabled, apply the spatial filter
@@ -298,16 +300,15 @@ function apply_spatial_filter(){
     });
     {% endif %}
 
-//generates a pycsw bbox from leaflet bounds    
+// Generates a pycsw bbox from leaflet bounds    
 function yx (b){
   if (b && b._southWest){
     return [b._southWest.lng,b._southWest.lat,b._northEast.lng,b._northEast.lat].join(',');
   }
 }
 
+// Creates or sets the filter rectangle and adds it to map
 var rectangle;
-
-// creates or sets the filter rectangle and adds it to map
 function setRectangle(bbox){
   if (rectangle){
       rectangle.setBounds(bbox)
@@ -319,7 +320,7 @@ function setRectangle(bbox){
   map.addLayer(rectangle);
 }
 
-// en/disables the spatial filter, the layer is removed or added at 95% map bounds
+// Dis/en-ables the spatial filter, the layer is removed or added at 95% map bounds
 function trigger_spatial_filter(){
     if (map.hasLayer(rectangle)){
       rectangle.remove();
@@ -327,7 +328,5 @@ function trigger_spatial_filter(){
       setRectangle(map.getBounds().pad(-0.95));
     }
 }
-  
 </script>
-
 {% endblock %}

--- a/pycsw/ogc/api/templates/items.html
+++ b/pycsw/ogc/api/templates/items.html
@@ -211,6 +211,7 @@ function sort(val){
 function facet(val){
   location.href="{{updateurl('facets','facetprop')}}".replace('facetprop',val);
 }
+//if url has a bbox, enable the spatial filter 
 {% if 'bbox' in attrs.keys() and (attrs['bbox'].split('%2C')|length) == 4 %}
 var bbox = [
           [{{ attrs['bbox'].split('%2C')[1] }}, {{ attrs['bbox'].split('%2C')[0] }}], 
@@ -219,8 +220,10 @@ var bbox = [
 {% else %}
 var bbox = null;
 {% endif %}
+
+//if filter enabled, apply the spatial filter
 function apply_spatial_filter(){
-  if ($('#spatial-filter-check').attr('checked')) {
+  if (map.hasLayer(rectangle)){
     location.href="{{ updateurl('bbox','tmptmp') }}".replace('tmptmp',yx(rectangle.getBounds()));
   }
 }
@@ -258,6 +261,7 @@ function apply_spatial_filter(){
     }
     {% endif %}
     
+    //set rectangle if page initializes with a spatial filter
     if (bbox){
       setRectangle(bbox);
       map.fitBounds(bbox);
@@ -268,6 +272,7 @@ function apply_spatial_filter(){
         dashArray: '',
         fillOpacity: 0.5
     }
+
     {% if data['features'] %}
     $(document).ready(function() {
         $('#items-table-table tr').on('mouseenter', function(e){
@@ -293,6 +298,7 @@ function apply_spatial_filter(){
     });
     {% endif %}
 
+//generates a pycsw bbox from leaflet bounds    
 function yx (b){
   if (b && b._southWest){
     return [b._southWest.lng,b._southWest.lat,b._northEast.lng,b._northEast.lat].join(',');
@@ -301,27 +307,23 @@ function yx (b){
 
 var rectangle;
 
+// creates or sets the filter rectangle and adds it to map
 function setRectangle(bbox){
   if (rectangle){
       rectangle.setBounds(bbox)
   } else {
       rectangle = L.rectangle(bbox);
       rectangle.editing.enable();
-      rectangle.on('edit', function() {
-        bbox = rectangle.getBounds();
-        console.log(rectangle.getBounds().toString());
-      });
+      rectangle.setStyle({color :'green'});
   }
   map.addLayer(rectangle);
 }
 
+// en/disables the spatial filter, the layer is removed or added at 95% map bounds
 function trigger_spatial_filter(){
     if (map.hasLayer(rectangle)){
-      console.log(bbox);
       rectangle.remove();
-      bbox = null;
     } else {
-      console.log(map.getBounds().pad(-0.95));
       setRectangle(map.getBounds().pad(-0.95));
     }
 }


### PR DESCRIPTION
# Overview

This adds a spatial filter option to UI.
Users can enable a bbox filter (or by adding the bbox parameter to url)
the bbox can be moved or resized, click apply to activate the filter

![image](https://github.com/user-attachments/assets/56236b1a-a3dc-42b6-954f-b27df54d1928)


# Related Issue / Discussion

#975

# Additional Information

Common functionality works, operates against bbox=1,2,3,4, but not when a bbox is used in CQL

Let me know in which direction to further develop, or to convert to WIP?

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
