### PR TITLE
[records] fix hierarchy links in contacts

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1217,9 +1217,7 @@ def record2json(record, url, collection, mode='ogcapi-records'):
                             'postalCode': cnt.get('postcode', ''),
                             'country': cnt.get('country', '')
                         }],
-                        'links': [{
-                            'href': cnt.get('onlineresource')
-                        }]
+                        'links': [cnt.get('onlineresource')]
                     })
                 except Exception as err:
                     LOGGER.exception(f"failed to parse contact of {record.identifier}: {err}")


### PR DESCRIPTION
# Overview

remove the 'href' element from the response hierarchy, it is not [specified](https://github.com/opengeospatial/ogcapi-records/blob/master/core/openapi/schemas/contact.yaml)

# Related Issue / Discussion

#1027

# Additional Information

in a next iteration we could be more explicit on how the link is formatted, and facilitate multiple links

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
