### PR TITLE
decode q param, when entering it in search box

### DIFF
--- a/pycsw/ogc/api/templates/items.html
+++ b/pycsw/ogc/api/templates/items.html
@@ -85,8 +85,11 @@ endmacro %}
     <div class="col-md-4">
       <form action="{{ nav_links.self.split('?')[0] }}" method="GET">
       <div class="input-group mb-3"> 
-          <input type="text" class="form-control" name="q" placeholder="Search" value="{{ attrs['q'] }}">
-          <input class="btn btn-outline-secondary" type="submit" value="Search"></input>
+        <input type="text" class="form-control" name="q" placeholder="Search" id="tbq" value="">
+        <script>
+          $('#tbq').val(decodeURIComponent("{{ attrs['q'].replace('+',' ') }}"))
+        </script>
+        <input class="btn btn-outline-secondary" type="submit" value="Search"></input>
       </div>
       </form>
     </div>


### PR DESCRIPTION
# Overview
 
this decodes the q parameter before entering it in the search box, it also replaces + by ' ', because it is not picked up by decode

# Related Issue / Discussion

#1036

# Additional Information

i'm using js to decode, because the urllib (with quote) library is currently not available in the jinja template, would you prefer to use python to decode?

To some, this may look like a vulnerability option to inject js via querystring, it is not the case, because the q parameter is carefully checked. try things like

https://demo.pycsw.org/cite/collections/metadata:main/items?q=%27%3Cscript%3Ealert(55)%3C%2Fscript%3E

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
