### PR TITLE
STAC API: implement queryable collections

### DIFF
--- a/docs/stac.rst
+++ b/docs/stac.rst
@@ -61,6 +61,15 @@ Request Examples
   http://localhost:8000/stac/openapi
   # collections
   http://localhost:8000/stac/collections
+  # collections query, full text search
+  http://localhost:8000/stac/collections?q=sentinel
+  # collections query, spatial query
+  http://localhost:8000/stac/collections?bbox=-142,42,-52,84
+  # collections query, full text search and spatial query
+  http://localhost:8000/stac/collections?q=sentinel,bbox=-142,42,-52,84
+  # collections query, limiting results
+  http://localhost:8000/stac/collections?limit=2
+  # collections query, spatial query
   # single collection
   http://localhost:8000/stac/collections/metadata:main
   # collection queryables, all records

--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -77,6 +77,7 @@ class Repository(object):
             # for sqlite < 0.7, we need to to this on a per-connection basis
             if engine.name in ['sqlite', 'sqlite3'] and __version__ >= '0.7':
                 from sqlalchemy import event
+
                 @event.listens_for(engine, "connect")
                 def connect(dbapi_connection, connection_rec):
                     create_custom_sql_functions(dbapi_connection)
@@ -335,7 +336,7 @@ class Repository(object):
         query = self.session.query(self.dataset).filter(column.in_(ids))
         return self._get_repo_filter(query).all()
 
-    def query_collections(self):
+    def query_collections(self, filters=None, limit=10):
         ''' Query for parent collections '''
 
         column = getattr(self.dataset,
@@ -352,7 +353,11 @@ class Repository(object):
 
         query = self.session.query(self.dataset).filter(column.in_(ids))
 
-        return self._get_repo_filter(query).all()
+        if filters is not None:
+            LOGGER.debug('Querying repository with additional filters')
+            return self._get_repo_filter(query).filter(filters).limit(limit).all()
+
+        return self._get_repo_filter(query).limit(limit).all()
 
     def query_domain(self, domain, typenames, domainquerytype='list',
                      count=False):

--- a/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
+++ b/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
@@ -49,7 +49,7 @@ def test_landing_page(config):
 
     assert content['stac_version'] == '1.0.0'
     assert content['type'] == 'Catalog'
-    assert len(content['conformsTo']) == 15
+    assert len(content['conformsTo']) == 18
     assert len(content['keywords']) == 3
 
 
@@ -70,13 +70,16 @@ def test_conformance(config):
     assert headers['Content-Type'] == 'application/json'
     assert status == 200
 
-    assert len(content['conformsTo']) == 15
+    assert len(content['conformsTo']) == 18
 
     conformances = [
+        'http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/simple-query',
         'https://api.stacspec.org/v1.0.0/core',
         'https://api.stacspec.org/v1.0.0/ogcapi-features',
         'https://api.stacspec.org/v1.0.0/item-search',
-        'https://api.stacspec.org/v1.0.0/item-search#filter'
+        'https://api.stacspec.org/v1.0.0/item-search#filter',
+        'https://api.stacspec.org/v1.0.0-rc.1/collection-search',
+        'https://api.stacspec.org/v1.0.0-rc.1/collection-search#free-text'
     ]
 
     for conformance in conformances:
@@ -92,9 +95,17 @@ def test_collections(config):
     assert status == 200
     assert len(content['links']) == 3
 
-    assert len(content['collections']) == 1
+    assert len(content['collections']) == 0
     assert len(content['collections']) == content['numberMatched']
     assert len(content['collections']) == content['numberReturned']
+
+    headers, status, content = api.collections({}, {'limit': 0, 'f': 'json'})
+    content = json.loads(content)
+
+    assert headers['Content-Type'] == 'application/json'
+    assert status == 200
+    assert len(content['collections']) == 0
+
 
 def test_queryables(config):
     api = STACAPI(config)


### PR DESCRIPTION
# Overview
Adds queryable support to `/collections` per https://github.com/stac-api-extensions/collection-search

Note that this PR **removes** `metadata:main` as a STAC API collection, the idea being any STAC collections need to be transacted into pycsw in order to appear on `/collections` responses.

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
