### PR TITLE
[ogcapi - records] use dates related to records only 

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1165,16 +1165,20 @@ def record2json(record, url, collection, mode='ogcapi-records'):
             record.otherconstraints = [record.otherconstraints]
             record_dict['properties']['license'] = ", ".join(record.otherconstraints)
 
-    record_dict['properties']['updated'] = record.insert_date
 
     if record.type:
         record_dict['properties']['type'] = record.type
 
-    if record.date_creation:
-        record_dict['properties']['created'] = record.date_creation
+    record_dict['properties']['updated'] = record.insert_date # this is always populated
+    
+    if record.date: # date is used in some schema's (DC)
+        record_dict['properties']['updated'] = record.date   
 
-    if record.date_modified:
+    if record.date_modified: # used in ISO
         record_dict['properties']['updated'] = record.date_modified
+
+    # pycsw does not capture date of record creation, use updated
+    record_dict['properties']['created'] = record_dict['properties']['updated']
 
     if record.language:
         record_dict['properties']['language'] = record.language


### PR DESCRIPTION

# Overview

ogcapi-records decided that created/modified represent the record, not the resource

since most of the metadata schema's do not advertise a record creation date, we can only duplicate created and modified

# Related Issue / Discussion

#1045 and #1044

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
