### PR TITLE
Fix Content-Length header when compressing gzip

### DIFF
--- a/pycsw/wsgi.py
+++ b/pycsw/wsgi.py
@@ -128,7 +128,10 @@ def compress_response(response, compression_level):
     gzipfile.write(response)
     gzipfile.close()
     compressed_response = buf.getvalue()
-    compression_headers = {'Content-Encoding': 'gzip'}
+    compression_headers = {
+        'Content-Encoding': 'gzip',
+        'Content-Length': str(len(compressed_response)),
+    }
     return compressed_response, compression_headers
 
 


### PR DESCRIPTION
# Overview

pycsw is sending the same `Content-Length` header when compressing gzip or not. The problem that this lead to is not always visible, but some browsers like Chrome and Safari when using HTTP2 are truncating connections when the length header is not matching the real response.

*`Content-Length`* should always be the length of bytes sent to the client, not the length of uncompressed content.

# Related Issue / Discussion

See also #954

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
