### PR TITLE
fix OARec language parsing

### DIFF
--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1764,7 +1764,7 @@ def _parse_oarec_record(context, repos, record):
 
     _set(context, recobj, 'pycsw:AnyText', ' '.join([str(t) for t in util.get_anytext_from_obj(record)]))
 
-    _set(context, recobj, 'pycsw:Language', record['properties'].get('language'))
+    _set(context, recobj, 'pycsw:Language', record['properties'].get('language', {}).get('code'))
     _set(context, recobj, 'pycsw:Type', record['properties']['type'])
     _set(context, recobj, 'pycsw:Title', record['properties']['title'])
     _set(context, recobj, 'pycsw:Abstract', record['properties'].get('description'))

--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -511,6 +511,7 @@ class Repository(object):
                                 self.dataset, self.context.md_core_model['mappings']['pycsw:XML']))
                         }, synchronize_session='fetch')
                 self.session.commit()
+                LOGGER.debug('Updated %d records', rows)
                 return rows
             except Exception as err:
                 self.session.rollback()
@@ -521,6 +522,7 @@ class Repository(object):
     def delete(self, constraint):
         ''' Delete a record from the repository '''
 
+        LOGGER.debug('Deleting record with constraint: %s', constraint)
         try:
             self.session.begin()
             rows = self._get_repo_filter(self.session.query(self.dataset)).filter(
@@ -542,6 +544,7 @@ class Repository(object):
                             synchronize_session='fetch')
 
             self.session.commit()
+            LOGGER.debug('Deleted %d records', rows)
         except Exception as err:
             self.session.rollback()
             msg = 'Cannot commit to repository'

--- a/tests/functionaltests/suites/oarec/conftest.py
+++ b/tests/functionaltests/suites/oarec/conftest.py
@@ -233,7 +233,9 @@ def sample_record():
                     ]
                 }
             ],
-            "language": "en",
+            "language": {
+                "code": "en"
+            },
             "type": "dataset",
             "created": "2011-11-11",
             "updated": "2000-09-01",


### PR DESCRIPTION
# Overview
Fixes OARec language handling (object instead of string) as per OARec Part 1 updates.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
