### PR TITLE
split keywords by , in facet, then recalculate

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1098,6 +1098,22 @@ class API:
                     'value': fq[0],
                     'count': fq[1]
                 })
+            
+            if facet in ['keywords']:
+                splitkws = {}
+                for k in facets_results[facet]['buckets']:
+                    if 'value' in k.keys() and k['value'] not in [None,''] and int(k['count']) > 0:
+                        if ',' in k['value']: # split kws by ,
+                            for k2 in k['value'].split(','):
+                                splitkws[k2.lower()] = int(k['count']) + int(splitkws.get(k2.lower(),0))
+                        else: 
+                            splitkws[k['value'].lower()] = int(k['count']) + int(splitkws.get(k['value'].lower(),0))
+                facets_results[facet]['buckets'] = [] # reset facet, populate it again       
+                for k,v in splitkws.items():
+                    facets_results[facet]['buckets'].append({
+                        'value': k,
+                        'count': v
+                    })
 
         return facets_results
 


### PR DESCRIPTION
# Overview

This PR introduces a procedure which splits keywords by ',' and recalculates totals after db query
Similar mechanism could be used for other fields which are ,-separated
I see 2 alternatives for this PR:
- keywords not to be stored as concatenated string, but actual list
- introduce an in-db procedure to split the keywords-string as part of the facet query

# Related Issue / Discussion

resolves #1065 

# Additional Information

![image](https://github.com/user-attachments/assets/5b63a10d-fc19-4e87-a579-8cf5528d228c)


# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
