### PR TITLE
improve facet layout, max 8, sort by count, reset

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -31,6 +31,7 @@
 
 import json
 import logging
+from operator import itemgetter
 import os
 from urllib.parse import urlencode, quote
 
@@ -1098,6 +1099,8 @@ class API:
                     'value': fq[0],
                     'count': fq[1]
                 })
+
+            facets_results[facet]['buckets'].sort(key=itemgetter('count'), reverse=True)
 
         return facets_results
 

--- a/pycsw/ogc/api/templates/items.html
+++ b/pycsw/ogc/api/templates/items.html
@@ -58,13 +58,14 @@
   for at in attrs.keys() %}{%
     if at != 'offset' %}{%
       if attrs[at] not in [None,''] %}{% 
-        if key not in [None,''] and key == at %}&{{ at }}={{ val }}{% 
+        if key not in [None,''] and key == at %}{% 
+          if val != '' %}&{{ at }}={{ val }}{% endif %}{% 
         else %}&{{ at }}={{ attrs[at] }}{% 
         endif %}{% 
       endif %}{% 
     endif %}{%
-    if key not in attrs.keys() %}&{{ key }}={{ val }}{% endif %}{% 
-  endfor %}{% 
+  endfor %}{%
+  if key not in attrs.keys() %}&{{ key }}={{ val }}{% endif %}{% 
 endmacro %}
 
 {% macro reseturl(key,val) %}{{ 
@@ -122,18 +123,30 @@ endmacro %}
         </div>
         {% if data['facets'] %}
         {% for facet in data['facets'].keys() %}
+        {% if data['facets'][facet]['buckets']|length > 0 %}
         <div class="card mt-3">
-          <div class="card-header text-capitalize">{{ facet }}</div>
+          <div class="card-header text-capitalize">{{ facet }} {% if facet in attrs.keys() %}
+            <a href="{{ updateurl(facet,'') }}"
+            class="btn btn-sm btn-outline-secondary" style="float:right">Reset</a>
+            {% endif %}</div>
           <div class="card-body">
-            {% for bucket in data['facets'][facet].buckets %}
+            {% for bucket in data['facets'][facet]['buckets'] %}
+            {% if loop.index == 8 %}
+              <div id="more-{{facet}}" class="collapse">
+            {% endif %}
             {% if bucket['value'] %}
             <a href="{{ updateurl(facet,bucket['value']) }}" title="{{bucket['value']}}"
               >{{(bucket['value'] or "") | truncate(20, False, '..') | capitalize }}</a>
             <span class="badge rounded-pill bg-secondary" style="float:right">{{bucket['count']}}</span><br>
             {% endif %}
             {% endfor %}
+            {% if data['facets'][facet]['buckets']|length > 7 %}</div>
+            <button onclick="$('#more-{{facet}}').toggle()" 
+              class="btn btn-sm btn-outline-secondary mt-2">Show more</button>
+            {% endif %}
           </div>
         </div>
+        {% endif %}
         {% endfor %}
         {% endif %}
       </div>


### PR DESCRIPTION
# Overview

This improves some aspects on facets display in items html:
- order by count
- show first 8 buckets and a button to open more buckets
- add a reset button to those facets which are applied as filter
- hide facet if it does not contain buckets
- fix a bug on duplicate filter add in url

![image](https://github.com/user-attachments/assets/204ed2a1-d326-4129-8723-d417185e4f06)
v
![image](https://github.com/user-attachments/assets/e77efdec-b9c3-4de1-8332-55e61dae8a27)

# Related Issue / Discussion

resolves #1066

# Additional Information

related to #1065

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
