### PR TITLE
Fixed the case of multiple publishers and contributors for DublinCore metadata

### DIFF
--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -1543,8 +1543,13 @@ class Csw2(object):
                 'dc:language', 'dc:rights', 'dct:alternative']:
                     val = util.getqattr(recobj, queryables[i]['dbcol'])
                     if val:
-                        etree.SubElement(record,
-                        util.nspath_eval(i, self.parent.context.namespaces)).text = val
+                        if isinstance(val, list): # if there are multiple publishers or contributors
+                            for v in val:
+                                etree.SubElement(record,
+                                util.nspath_eval(i, self.parent.context.namespaces)).text = str(v)
+                        else:
+                            etree.SubElement(record,
+                            util.nspath_eval(i, self.parent.context.namespaces)).text = val
                 val = util.getqattr(recobj, queryables['dct:spatial']['dbcol'])
                 if val:
                     etree.SubElement(record,


### PR DESCRIPTION
# Overview
Fixes issue#1069
When requesting to download DublinCore metedata, the request fails if there are any publishers because the publishers are in a list form. This PR handles the list of publishers and contributors.

# Related Issue / Discussion
[issue#1069](https://github.com/geopython/pycsw/issues/1069)

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
