### PR TITLE
use conditionapplyingtoaccessanduse to populate oa-records:rights

### DIFF
--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1670,7 +1670,7 @@ def _parse_dc(context, repos, exml):
     _set(context, recobj, 'pycsw:AlternateTitle', md.alternative)
     _set(context, recobj, 'pycsw:Abstract', md.abstract)
 
-    if len(md.subjects) > 0 and None not in md.subjects:
+    if md.subjects is not None and len(md.subjects) > 0 and None not in md.subjects:
         _set(context, recobj, 'pycsw:Keywords', ','.join(md.subjects))
 
     _set(context, recobj, 'pycsw:ParentIdentifier', md.ispartof)
@@ -1682,7 +1682,7 @@ def _parse_dc(context, repos, exml):
     _set(context, recobj, 'pycsw:Publisher', md.publisher)
     _set(context, recobj, 'pycsw:Contributor', md.contributor)
     _set(context, recobj, 'pycsw:OrganizationName', md.rightsholder)
-    if len(md.rights) > 0 and None not in md.rights:
+    if md.rights is not None and len(md.rights) > 0 and None not in md.rights:
         _set(context, recobj, 'pycsw:ConditionApplyingToAccessAndUse', ','.join(md.rights))
     _set(context, recobj, 'pycsw:AccessConstraints', md.accessrights)
     _set(context, recobj, 'pycsw:OtherConstraints', md.license)

--- a/pycsw/core/metadata.py
+++ b/pycsw/core/metadata.py
@@ -1682,6 +1682,8 @@ def _parse_dc(context, repos, exml):
     _set(context, recobj, 'pycsw:Publisher', md.publisher)
     _set(context, recobj, 'pycsw:Contributor', md.contributor)
     _set(context, recobj, 'pycsw:OrganizationName', md.rightsholder)
+    if len(md.rights) > 0 and None not in md.rights:
+        _set(context, recobj, 'pycsw:ConditionApplyingToAccessAndUse', ','.join(md.rights))
     _set(context, recobj, 'pycsw:AccessConstraints', md.accessrights)
     _set(context, recobj, 'pycsw:OtherConstraints', md.license)
     _set(context, recobj, 'pycsw:Date', md.date)

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1201,6 +1201,10 @@ def record2json(record, url, collection, mode='ogcapi-records'):
             record.otherconstraints = [record.otherconstraints]
             record_dict['properties']['license'] = ", ".join(record.otherconstraints)
 
+    if record.conditionapplyingtoaccessanduse:
+        if isinstance(record.conditionapplyingtoaccessanduse, str) and record.conditionapplyingtoaccessanduse not in [None, 'None']:
+            record_dict['properties']['rights'] = record.conditionapplyingtoaccessanduse
+
     record_dict['properties']['updated'] = record.insert_date
 
     if record.type:


### PR DESCRIPTION
# Overview

uselimitation is used in hnap (amongst others) to represent dc:rights, this field is captured in conditionapplyingtoaccessanduse 
use that field to populate the rights property in oa-records
also map the dc:rights to this property
(i'm unsure about the queryable mapping gmd:accessconstraints-dc:rights)

# Related Issue / Discussion

suggestion for #1077

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
