### PR TITLE
OARec: use striptags in exception templates

### DIFF
--- a/pycsw/ogc/api/templates/exception.html
+++ b/pycsw/ogc/api/templates/exception.html
@@ -3,6 +3,6 @@
 {% block body %}
     <section id="exception">
       <h2>Exception</h2>
-      <p>{{ data['description'] }}</p>
+      <p>{{ data['description'] | striptags }}</p>
     </section>
 {% endblock %}


### PR DESCRIPTION
# Overview
Strips tags in exception report HTML.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
