### PR TITLE
Update to use latest version of pygeoif

### DIFF
--- a/pycsw/core/pygeofilter_evaluate.py
+++ b/pycsw/core/pygeofilter_evaluate.py
@@ -42,8 +42,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class PycswFilterEvaluator(SQLAlchemyFilterEvaluator):
-    def __init__(self, field_mapping=None, dbtype='sqlite'):
-        super().__init__(field_mapping)
+    def __init__(self, field_mapping=None, dbtype='sqlite', undefined_as_null=None):
+        super().__init__(field_mapping, undefined_as_null=undefined_as_null)
         self._pycsw_dbtype = dbtype
 
     @handle(ast.BBox)

--- a/requirements-standalone.txt
+++ b/requirements-standalone.txt
@@ -2,4 +2,4 @@ SQLAlchemy<2.0.0
 Flask
 pygeofilter
 PyYAML
-pygeoif==0.7
+pygeoif


### PR DESCRIPTION
# Overview

Updates the project to use the latest version of `pygeoif`. This was pinned in #789, but this no longer seems necessary. 
See also https://github.com/geopython/pygeofilter/pull/64. 

One minor update required to work with the latest `pygeofilter` API (a dependency of `pygeoif`):

https://github.com/geopython/pygeofilter/blob/25743c9c5472f1d77a76607e3364418919d1f25e/pygeofilter/backends/sqlalchemy/filters.py#L260

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [X] I'd like to contribute this update to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
