### PR TITLE
Replace imp module with importlib module

### DIFF
--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -193,12 +193,12 @@ class Csw(object):
         if self.config.has_option('repository', 'mappings'):
             # override default repository mappings
             try:
-                import imp
+                import importlib
                 module = self.config.get('repository', 'mappings')
                 if os.sep in module:  # filepath
                     modulename = '%s' % os.path.splitext(module)[0].replace(
                         os.sep, '.')
-                    mappings = imp.load_source(modulename, module)
+                    mappings = importlib(modulename)
                 else:  # dotted name
                     mappings = __import__(module, fromlist=[''])
                 LOGGER.info('Loading custom repository mappings '


### PR DESCRIPTION
# Overview
Replace `imp` module with `importlib` module to make compatible with python >=3.12

# Related Issue / Discussion
Close: #1013 

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
