### PR TITLE
encode content before counting

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -188,7 +188,7 @@ class API:
             pretty_print = str2bool(self.config['server'].get('pretty_print', False))
             content = to_json(data, pretty_print)
 
-        headers['Content-Length'] = len(content)
+        headers['Content-Length'] = len(content.encode('utf-8'))
 
         return headers, status, content
 

--- a/pycsw/wsgi.py
+++ b/pycsw/wsgi.py
@@ -83,7 +83,7 @@ def application_dispatcher(env):
     csw = server.Csw(configuration_path, env)
     status, contents = csw.dispatch_wsgi()
     headers = {
-        'Content-Length': str(len(contents)),
+        'Content-Length': str(len(contents.encode("utf-8"))),
         'Content-Type': str(csw.contenttype)
     }
     if "gzip" in env.get("HTTP_ACCEPT_ENCODING", ""):


### PR DESCRIPTION
# Overview

python counts string length differently when having special characters, therefore an incorrect content length is sent, and the request is truncated, count is correct if it is first encoded

# Related Issue / Discussion

fixes #1091

# Additional Information

to be discussed if it makes sense to return also the content itself encoded

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
