### PR TITLE
revert encode change, because contents is of type bites

### DIFF
--- a/pycsw/wsgi.py
+++ b/pycsw/wsgi.py
@@ -83,7 +83,7 @@ def application_dispatcher(env):
     csw = server.Csw(configuration_path, env)
     status, contents = csw.dispatch_wsgi()
     headers = {
-        'Content-Length': str(len(contents.encode("utf-8"))),
+        'Content-Length': str(len(contents)),
         'Content-Type': str(csw.contenttype)
     }
     if "gzip" in env.get("HTTP_ACCEPT_ENCODING", ""):


### PR DESCRIPTION

# Overview

reverts partial change in #1092, which broke csw

# Related Issue / Discussion

#1091

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
