### PR TITLE
make GeoJSON to bbox handling more robust

### DIFF
--- a/pycsw/core/util.py
+++ b/pycsw/core/util.py
@@ -5,7 +5,7 @@
 #          Angelos Tzotsos <tzotsos@gmail.com>
 #          Ricardo Garcia Silva <ricardo.garcia.silva@gmail.com>
 #
-# Copyright (c) 2023 Tom Kralidis
+# Copyright (c) 2025 Tom Kralidis
 # Copyright (c) 2015 Angelos Tzotsos
 # Copyright (c) 2017 Ricardo Garcia Silva
 #
@@ -47,6 +47,7 @@ import typing
 
 from urllib.request import Request, urlopen
 from urllib.parse import urlparse
+from shapely.geometry import shape
 from shapely.wkt import loads
 from owslib.util import http_post
 
@@ -182,15 +183,8 @@ def wktenvelope2bbox(envelope):
 def geojson_geometry2bbox(geometry):
     """returns bbox string of GeoJSON geometry"""
 
-    geom_type = geometry.get('type')
-    coords = geometry.get('coordinates')
-
-    if geom_type == 'Point':
-        bbox = '%s,%s,%s,%s' % (coords[0], coords[1], coords[0], coords[1])
-    elif geom_type == 'Polygon':
-        bbox = '%s,%s,%s,%s' % (coords[0][0][0], coords[0][0][1], coords[0][2][0], coords[0][2][1])
-
-    return bbox
+    bounds = shape(geometry).bounds
+    return ','.join([str(b) for b in bounds])
 
 
 def wkt2geom(ewkt, bounds=True):

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+from shapely import from_geojson
 from shapely.wkt import loads
 
 from pycsw.core import util
@@ -386,3 +387,53 @@ def test_str2bool():
     assert not util.str2bool(False)
     assert not util.str2bool('off')
     assert not util.str2bool('no')
+
+
+@pytest.mark.parametrize("geometry,expected", [
+    ({
+        'type': 'Point',
+        'coordinates': [102.0, 0.5]
+     }, '102.0,0.5,102.0,0.5'), ({
+         'type': 'LineString',
+         'coordinates': [
+             [102.0, 0.0],
+             [103.0, 1.0],
+             [104.0, 0.0],
+             [105.0, 1.0]
+         ]
+      }, '102.0,0.0,105.0,1.0'), ({
+         'type': 'Polygon',
+         'coordinates': [[
+             [100.0, 0.0],
+             [101.0, 0.0],
+             [101.0, 1.0],
+             [100.0, 1.0],
+             [100.0, 0.0]
+         ]]
+      }, '100.0,0.0,101.0,1.0'), ({
+         'type': 'MultiPolygon',
+         'coordinates': [[[
+             [30.0, 20.0],
+             [45.0, 40.0],
+             [10.0, 40.0],
+             [30.0, 20.0]
+         ]], [[
+             [15.0, 5.0],
+             [40.0, 10.0],
+             [10.0, 20.0],
+             [5.0, 10.0],
+             [15.0, 5.0]
+         ]]]
+      }, '5.0,5.0,45.0,40.0'), ({
+         'type': 'MultiPoint',
+         'coordinates': [
+             [10.0, 40.0],
+             [40.0, 30.0],
+             [20.0, 20.0],
+             [30.0, 10.0]
+         ]
+      }, '10.0,10.0,40.0,40.0')
+])
+def test_geojson_geometry2bbox(geometry, expected):
+    bounds = util.geojson_geometry2bbox(geometry)
+    assert bounds == expected


### PR DESCRIPTION
# Overview
This PR updates GeoJSON bounds derivation support to utilize Shapely to handle any geometry.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
