### PR TITLE
fix STAC API POST limit parameter handling

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -739,6 +739,8 @@ class API:
                 return self.get_exception(400, headers_, 'InvalidParameterValue', msg)
             if limit > self.limit:
                 limit = self.limit
+        elif limit is not None:
+            pass
         else:
             limit = self.limit
 
@@ -747,6 +749,9 @@ class API:
         LOGGER.debug(f'Query: {query}')
         LOGGER.debug('Querying repository')
         count = query.count()
+        LOGGER.debug(f'count: {count}')
+        LOGGER.debug(f'limit: {limit}')
+        LOGGER.debug(f'offset: {offset}')
         records = query.limit(limit).offset(offset).all()
 
         returned = len(records)

--- a/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
+++ b/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
@@ -233,6 +233,11 @@ def test_items(config):
     for feature in content['features']:
         assert feature['collection'] == 'S2MSI1C'
 
+    # test limit
+    content = json.loads(api.items({}, {'limit': 1}, {})[2])
+
+    assert content['numberReturned'] == 1
+    assert content['numberMatched'] == 30
 
 def test_item(config):
     api = STACAPI(config)


### PR DESCRIPTION
# Overview
Fixes STAC API mode HTTP POST query `limit` parameter handling.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
