### PR TITLE
add datetime as queryable

### DIFF
--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -158,6 +158,7 @@ class Repository(object):
             'anytext': self.dataset.anytext,
             'bbox': self.dataset.wkt_geometry,
             'date': self.dataset.date,
+            'datetime': self.dataset.date,
             'time_begin': self.dataset.time_begin,
             'time_end': self.dataset.time_end,
             'platform': self.dataset.platform,

--- a/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
+++ b/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
@@ -173,6 +173,16 @@ def test_items(config):
     assert len(content['features']) == 10
     assert content['features'][5]['properties']['title'] == 'S2B_MSIL2A_20190910T095029_N0500_R079_T33UXQ_20230430T083712.SAFE'  # noqa
 
+    content = json.loads(api.items({}, None, {'sortby': 'datetime'})[2])
+
+    assert len(content['features']) == 10
+    assert content['features'][5]['properties']['title'] == 'S2B_MSIL2A_20190910T095029_N0500_R079_T33UXP_20230430T083712.SAFE'  # noqa
+
+    content = json.loads(api.items({}, None, {'sortby': '-datetime'})[2])
+
+    assert len(content['features']) == 10
+    assert content['features'][5]['properties']['title'] == 'S2B_MSIL1C_20190910T095029_N0500_R079_T33TXN_20230429T151337.SAFE'  # noqa
+
     params = {'filter': "title LIKE '%%sentinel%%'"}
     content = json.loads(api.items({}, None, params)[2])
     assert content['numberMatched'] == 3


### PR DESCRIPTION
# Overview
This PR adds `datetime` as a queryable (mapped against `pycsw:Date`) for STAC compatability.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
