### PR TITLE
cast postalcode/phone/fax as strings for CSW2/3

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -61,10 +61,10 @@ pycsw's runtime configuration is defined by ``default.yml``.  pycsw ships with a
 - **address**: the address of the provider contact
 - **city**: the city of the provider contact
 - **stateorprovince**: the province or territory of the provider contact
-- **postalcode**: the postal code of the provider contact
+- **postalcode**: the postal code of the provider contact (enclose in quotes)
 - **country**: the country of the provider contact
-- **phone**: the phone number of the provider contact
-- **fax**: the facsimile number of the provider contact
+- **phone**: the phone number of the provider contact (enclose in quotes)
+- **fax**: the facsimile number of the provider contact (enclose in quotes)
 - **email**: the email address of the provider contact
 - **url**: the URL to more information about the provider contact
 - **hours**: the hours of service to contact the provider

--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -192,11 +192,11 @@ class Csw2(object):
 
             etree.SubElement(phone, util.nspath_eval('ows:Voice',
             self.parent.context.namespaces)).text = \
-            metadata_main['contact'].get('phone', 'missing')
+            str(metadata_main['contact'].get('phone', 'missing'))
 
             etree.SubElement(phone, util.nspath_eval('ows:Facsimile',
             self.parent.context.namespaces)).text = \
-            metadata_main['contact'].get('fax', 'missing')
+            str(metadata_main['contact'].get('fax', 'missing'))
 
             address = etree.SubElement(contactinfo,
             util.nspath_eval('ows:Address', self.parent.context.namespaces))
@@ -218,7 +218,7 @@ class Csw2(object):
             etree.SubElement(address,
             util.nspath_eval('ows:PostalCode',
             self.parent.context.namespaces)).text = \
-            metadata_main['contact'].get('postalcode', 'missing')
+            str(metadata_main['contact'].get('postalcode', 'missing'))
 
             etree.SubElement(address,
             util.nspath_eval('ows:Country', self.parent.context.namespaces)).text = \

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -227,11 +227,11 @@ class Csw3(object):
 
             etree.SubElement(phone, util.nspath_eval('ows20:Voice',
             self.parent.context.namespaces)).text = \
-            metadata_main['contact'].get('phone', 'missing')
+            str(metadata_main['contact'].get('phone', 'missing'))
 
             etree.SubElement(phone, util.nspath_eval('ows20:Facsimile',
             self.parent.context.namespaces)).text = \
-            metadata_main['contact'].get('fax', 'missing')
+            str(metadata_main['contact'].get('fax', 'missing'))
 
             address = etree.SubElement(contactinfo,
             util.nspath_eval('ows20:Address', self.parent.context.namespaces))


### PR DESCRIPTION
# Overview
Casts postalcode/phone/fax into strings for CSW2/3.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
