### PR TITLE
Add logging import and create missing LOGGER for apiso profile

### DIFF
--- a/pycsw/plugins/profiles/apiso/apiso.py
+++ b/pycsw/plugins/profiles/apiso/apiso.py
@@ -30,10 +30,13 @@
 #
 # =================================================================
 
+import logging
 import os
 from pycsw.core import util
 from pycsw.core.etree import etree
 from pycsw.plugins.profiles import profile
+
+LOGGER = logging.getLogger(__name__)
 
 CODELIST = 'http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml'
 CODESPACE = 'ISOTC211/19115'


### PR DESCRIPTION
# Overview

Adding the missing import and setup of a `LOGGER` for `apiso.py`.

# Related Issue / Discussion

(None raised.)

# Additional Information

`write_extent()` in [pycsw/plugins/profiles/apiso/apiso.py:711](https://github.com/geopython/pycsw/blob/ef39705c1a8a29ab9da5a161159f94fbabde7ec7/pycsw/plugins/profiles/apiso/apiso.py#L711) tries to use `LOGGER` in an exception handler on line `711`, but the required `LOGGER` does not exist, causing an `UnboundLocal` exception, instead of a log entry.

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute the enclosed bugfix to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
