### PR TITLE
STAC: return native collections when available

### DIFF
--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -44,3 +44,4 @@ jobs:
         severity: CRITICAL,HIGH
         vuln-type: os,library
         image-ref: '${{ github.repository }}:${{ github.sha }}'
+        skip-dirs: docker/helm,docker/kubernetes

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -44,4 +44,4 @@ jobs:
         severity: CRITICAL,HIGH
         vuln-type: os,library
         image-ref: '${{ github.repository }}:${{ github.sha }}'
-        skip-dirs: docker/helm,docker/kubernetes
+        skip_dirs: docker/helm,docker/kubernetes

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -32,6 +32,7 @@ jobs:
         severity: CRITICAL,HIGH
         scanners: vuln,misconfig,secret
         scan-ref: .
+        skip-dirs: docker/helm,docker/kubernetes
     - name: Build locally the image from Dockerfile
       run: |
         docker buildx build -t ${{ github.repository }}:${{ github.sha }} --platform linux/amd64 --no-cache -f Dockerfile .
@@ -44,4 +45,3 @@ jobs:
         severity: CRITICAL,HIGH
         vuln-type: os,library
         image-ref: '${{ github.repository }}:${{ github.sha }}'
-        skip_dirs: docker/helm,docker/kubernetes

--- a/pycsw/stac/api.py
+++ b/pycsw/stac/api.py
@@ -488,6 +488,9 @@ class STACAPI(API):
         :returns: `dict` of collection
         """
 
+        if 'json' in collection_info.metadata_type and collection_info.type == 'collection':
+            return json.loads(collection_info.metadata)
+
         if collection_name == 'metadata:main':
             id_ = collection_name
             title = self.config['metadata']['identification']['title']
@@ -549,7 +552,7 @@ class STACAPI(API):
             if collection is not None:
                 data['collection'] = collection
             if data is not None and 'id' in data:
-                item=data['id']
+                item = data['id']
 
             return super().manage_collection_item(
                 headers_=headers_, action=action, item=item, data=data)

--- a/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
+++ b/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
@@ -108,6 +108,21 @@ def test_collections(config):
     assert len(content['collections']) == 0
 
 
+def test_collection(config):
+    api = STACAPI(config)
+    headers, status, content = api.collection({}, {'f': 'json'}, 'simple-collection')  # noqa
+    content = json.loads(content)
+
+    assert headers['Content-Type'] == 'application/json'
+    assert status == 200
+    assert len(content['links']) == 4
+
+    assert content['id'] == 'simple-collection'
+    assert content['title'] == 'Simple Example Collection'
+    assert 'summaries' in content
+    assert 'statistics' in content['summaries']
+
+
 def test_queryables(config):
     api = STACAPI(config)
     headers, status, content = api.queryables({}, {})
@@ -408,7 +423,7 @@ def test_json_transaction(config, sample_collection, sample_item,
 
     # ensure collection is empty
 
-    headers, status, content = api.items({}, {}, {'collections': collection_id, 'f': 'json'})  # , collection=collection_id)
+    headers, status, content = api.items({}, {}, {'collections': collection_id, 'f': 'json'})  # noqa
 
     content = json.loads(content)
 


### PR DESCRIPTION
# Overview
When a record in the repository is a STAC collection, do not generate by assembly, but early out return the collection as stored.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
