### PR TITLE
keep Dockerfile as editable install (#1113)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ COPY --chown=pycsw . .
 COPY docker/pycsw.yml ${PYCSW_CONFIG}
 COPY docker/entrypoint.py /usr/local/bin/entrypoint.py
 
-RUN pip3 install .
+RUN pip install -e . --config-settings editable_mode=strict
 
 WORKDIR /home/pycsw
 


### PR DESCRIPTION
# Overview
This PR keeps a single, editable install for Docker setup.

# Related Issue / Discussion
#1113
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
