### PR TITLE
Solr part2

### DIFF
--- a/docker/compose/solr/README.md
+++ b/docker/compose/solr/README.md
@@ -1,13 +1,21 @@
 # pycsw with SOLR backend
 
+## metno work
 
+@epifiano and the team at metno did amazing work in their implementation of pycsw, this work is inspired by their work
+
+- https://github.com/epifanio/adc-pycsw
+- https://github.com/geopython/pygeofilter/blob/main/.github/workflows/main.yml#L41
+- https://github.com/geopython/pygeofilter/blob/main/tests/backends/solr/test_evaluate.py
+- https://github.com/magnarem/metsis-solr-configset
+
+## security
 
 Enable security in security.json, see also [solr documentation](https://solr.apache.org/guide/solr/latest/deployment-guide/authentication-and-authorization-plugins.html#using-security-json-with-solr)
 
-
 ## SOLR is used in QWC
 
-some links from their docs
+Some links from their docs
 
 - https://github.com/qwc-services/qwc-fulltext-search-service/?tab=readme-ov-file#solr-backend
 

--- a/docker/compose/solr/docker-compose.yml
+++ b/docker/compose/solr/docker-compose.yml
@@ -46,6 +46,14 @@ services:
   solr:
     container_name: solr
     image: solr:slim
+    healthcheck:
+      test: >-
+        curl -s -A 'healthcheck'  http://localhost:8983/solr/gettingstarted/admin/ping?wt=json \
+        | grep -q '"status":"OK"'
+      start_period: 15s
+      interval: 10s
+      timeout: 5s
+      retries: 3
     volumes:
       - solr-data:/var/solr
     ports:
@@ -58,7 +66,8 @@ services:
   pycsw:
     container_name: pycsw
     depends_on:
-      - solr
+      solr:
+        condition: service_healthy
     build: ../../..
     environment:
         PYCSW_SERVER_URL: http://localhost:8000
@@ -66,8 +75,8 @@ services:
       - 8000:8000
     volumes:
       - ./pycsw-solr.yml:/etc/pycsw/pycsw.yml
-      - ./solr_helper.py:/usr/local/lib/python3.10/site-packages/pycsw/pycsw/plugins/repository/solr_helper.py
-      - ./solr_pycsw.py:/usr/local/lib/python3.10/site-packages/pycsw/pycsw/plugins/repository/solr_pycsw.py
+      - ./solr_helper.py:/usr/local/lib/python3.10/site-packages/pycsw/plugins/repository/solr_helper.py
+      - ./solr_pycsw.py:/usr/local/lib/python3.10/site-packages/pycsw/plugins/repository/solr_pycsw.py
     networks:
       - pycsw-net
 


### PR DESCRIPTION
# Overview

it adds a healthcheck=depends-on between solr and pycsw
it aims to fix config reader using yaml (not .ini)

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
