### PR TITLE
OARec: add timeStamp to items responses

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -29,6 +29,7 @@
 #
 # =================================================================
 
+from datetime import datetime
 import json
 import logging
 from operator import itemgetter
@@ -858,6 +859,8 @@ class API:
                 'href': f"{bind_url(url_)}offset={next_}",
                 'hreflang': self.config['server']['language']
             })
+
+        response['timeStamp'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
         if headers_['Content-Type'] == 'text/html':
             response['title'] = self.config['metadata']['identification']['title']

--- a/tests/functionaltests/suites/oarec/test_oarec_functional.py
+++ b/tests/functionaltests/suites/oarec/test_oarec_functional.py
@@ -4,7 +4,7 @@
 #          Angelos Tzotsos <gcpp.kalxas@gmail.com>
 #          Ricardo Garcia Silva <ricardo.garcia.silva@gmail.com>
 #
-# Copyright (c) 2024 Tom Kralidis
+# Copyright (c) 2025 Tom Kralidis
 # Copyright (c) 2022 Angelos Tzotsos
 # Copyright (c) 2023 Ricardo Garcia Silva
 #
@@ -125,6 +125,7 @@ def test_items(config):
     assert headers['Content-Type'] == 'application/json'
     assert content['type'] == 'FeatureCollection'
     assert len(content['links']) == 4
+    assert 'timeStamp' in content
     assert content['numberMatched'] == 12
     assert content['numberReturned'] == 10
     assert len(content['features']) == 10


### PR DESCRIPTION
# Overview
Adds `timeStamp` to OGC API - Records `.../items` responses.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
