### PR TITLE
fix value and type from dangling comma

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1308,7 +1308,7 @@ def record2json(record, url, collection, mode='ogcapi-records'):
                         'concepts': [{'id': c.get('name', '')} for c in theme.get('keywords', []) if 'name' in c and c['name'] not in [None, '']]
                     }
                     if 'thesaurus' in theme:
-                        theme_['scheme'] = theme['thesaurus'].get('url') or theme['thesaurus'].get('title'),
+                        theme_['scheme'] = theme['thesaurus'].get('url') or theme['thesaurus'].get('title')
                     elif 'scheme' in theme:
                         theme_['scheme'] = theme['scheme']
 


### PR DESCRIPTION
# Overview

Small but always annoying dangling comma, removing it so that `theme` thesaurus doesn't end up as a tuple.

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
