### PR TITLE
OARec: add sensible default handling (#1116)

### DIFF
--- a/pycsw/ogc/api/oapi.py
+++ b/pycsw/ogc/api/oapi.py
@@ -388,6 +388,7 @@ def gen_oapi(config, oapi_filepath, mode='ogcapi-records'):
     }
 
     oapi['paths']['/collections/{collectionId}/queryables'] = path2
+    oapi['components']['parameters']['collectionId']['default'] = 'metadata:main'  # noqa
 
     path = {
         'get': {

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -579,7 +579,7 @@ class API:
 
             LOGGER.debug(f'Transformed args: {args}')
 
-        if 'filter' in args:
+        if args.get('filter', {}):
             LOGGER.debug(f'CQL query specified {args["filter"]}')
             cql_query = args['filter']
             filter_lang = args.get('filter-lang')
@@ -856,7 +856,6 @@ class API:
                         'rel': 'first',
                         'title': 'items (first)',
                         'href': f'{bind_url(url_)}',
-                        'href': url_,
                         'hreflang': self.config['server']['language']
                     })
 


### PR DESCRIPTION
# Overview
Adds `metadata:main` as a default `collectionId` in OpenAPI document, as well as handles empty `filter` parameter on `.../items`.
# Related Issue / Discussion
#1116
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
