### PR TITLE
Removing apipkg dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 -r requirements-standalone.txt
+-r requirements-pg.txt
 
-apipkg==1.4
 pytest==6.2.4
 pytest-cov==2.12.0
 pytest-flake8==1.0.7

--- a/tests/functionaltests/conftest.py
+++ b/tests/functionaltests/conftest.py
@@ -35,19 +35,13 @@ import logging
 import os
 import re
 
-import apipkg
+import psycopg2
 import pytest
 
 from pycsw.core import admin
 from pycsw.core.config import StaticContext
 from pycsw.core.repository import Repository, setup
 from pycsw.ogc.api.util import yaml_load
-
-apipkg.initpkg("optionaldependencies", {
-    "psycopg2": "psycopg2",
-})
-
-from optionaldependencies import psycopg2  # NOQA: E402
 
 TESTS_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 


### PR DESCRIPTION
# Overview

Removing apipkg dependency based on Debian issue

# Related Issue / Discussion

https://github.com/geopython/pycsw/pull/536
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1120888

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
