### PR TITLE
Add legacy-cgi dependency for Python >= 3.13.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 click
 geolinks
+legacy-cgi; python_version >= '3.13'
 lxml
 OWSLib
 pyproj


### PR DESCRIPTION
# Overview

Python 3.13 drops the cgi & cgitb modules, legacy-cgi keeps these available.

# Related Issue / Discussion

Fixes: #1089

# Additional Information

https://peps.python.org/pep-0594/#cgi

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
