### PR TITLE
fix STAC API navigation links

### DIFF
--- a/pycsw/stac/api.py
+++ b/pycsw/stac/api.py
@@ -463,9 +463,15 @@ class STACAPI(API):
                     LOGGER.debug('Missing link relation; adding rel=related')
                     link['rel'] = 'related'
 
-        for count, value in enumerate(response2['links']):
-            if value['rel'] == 'alternate':
-                response2['links'].pop(count)
+        links2 = []
+
+        for link in response2['links']:
+            if link['rel'] in ['alternate', 'collection']:
+                continue
+            link['href'] = link['href'].replace('collections/metadata:main/items', 'search')
+            links2.append(link)
+
+        response2['links'] = links2
 
         response2['links'].extend([{
             'rel': 'root',

--- a/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
+++ b/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
@@ -167,6 +167,11 @@ def test_items(config):
             assert 'href' in link
             assert 'rel' in link
 
+    for link in content['links']:
+        assert 'href' in link
+        assert 'rel' in link
+        assert 'metadata:main' not in link['href']
+
     # test GET KVP requests
     content = json.loads(api.items({}, None, {'bbox': '-180,-90,180,90'})[2])
     assert len(content['features']) == 10


### PR DESCRIPTION
# Overview
This PR fixes STAC API navigation links to persist `/stac/search`.
# Related Issue / Discussion
#1167 
# Additional Information
None
# Contributions and Licensing
None
(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
