### PR TITLE
fix unpacking of collection JSON array types on POST queries (#1167)

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -591,7 +591,7 @@ class API:
 
             for p in ['limit', 'bbox', 'datetime', 'collections']:
                 if p in json_post_data:
-                    if p == 'bbox':
+                    if p in ['bbox', 'collections']:
                         args[p] = ','.join(map(str, json_post_data.get(p)))
                     else:
                         args[p] = json_post_data.get(p)


### PR DESCRIPTION
# Overview
This PR unpacks JSON payload array types for `collection` query parameters when handling GET and POST.
# Related Issue / Discussion
Fixes #1167
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
