### PR TITLE
update CQL2 handling in STAC API mode

### DIFF
--- a/docs/stac.rst
+++ b/docs/stac.rst
@@ -31,7 +31,12 @@ Search
 ^^^^^^
 
 * In addition to OGC API - Records ``/collections/metadata:main/items`` search,
-  STAC API specific searches are realized via ``/stac/search``
+  STAC API specific searches are realized via ``/stac/search`` which conforms to the STAC API items-search conformance class.
+
+Filtering
+^^^^^^^^^
+
+STAC API filtering is realized by `OGC Common Query Language (CQL2)`_ via HTTP GET and POST.  For GET requests, the `filter=` query parameter can be used.  For POST requests, a JSON payload with a `filter` property expressing the CQL2 can be used.
 
 Links and Assets
 ^^^^^^^^^^^^^^^^
@@ -113,6 +118,49 @@ Request Examples
   # collection item as GeoJSON
   http://localhost:8000/stac/collections/metadata:main/items/{itemId}
 
+  # CQL2 JSON (as curl commands)
+
+  # search by creation date
+  curl --location --request POST 'http://localhost:8000/stac/search' \
+      --header 'Content-Type: application/query-cql-json' \
+      --data-raw '{
+          "filter-lang": "cql2-json",
+          "filter": {
+              "op": "<=",
+              "args": [
+                  {
+                      "property": "date_creation"
+                  },
+                  "2025-12-15"
+              ]
+          }
+      }'
+
+  # search by creation date
+  curl --location --request POST 'http://localhost:8000/stac/search' \
+      --header 'Content-Type: application/query-cql-json' \
+      --data-raw '{
+        "filter-lang": "cql2-json",
+        "filter": {
+            "op": "and",
+            "args": [
+                {   
+                    "op": "in",
+                    "args": [
+                        {   
+                            "property": "parentidentifier"
+                        },  
+                        [   
+                            "sentinel-2-l2a"
+                        ]   
+                    ]   
+                }   
+            ]   
+        }   
+    }'
+
 .. _`SpatioTemporal Asset Catalog API version v1.0.0`: https://github.com/radiantearth/stac-api-spec
 .. _`STAC API - Transaction Extension Specification`: https://github.com/stac-api-extensions/transaction
 .. _`STAC API - Collection Transaction Extension`: https://github.com/stac-api-extensions/collection-transaction
+.. _`OGC Common Query Language (CQL2)`: https://docs.ogc.org/is/21-065r2/21-065r2.html
+

--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -158,10 +158,12 @@ class Repository(object):
             'anytext': self.dataset.anytext,
             'bbox': self.dataset.wkt_geometry,
             'date': self.dataset.date,
+            'date_creation': self.dataset.date_creation,
             'datetime': self.dataset.date,
             'time_begin': self.dataset.time_begin,
             'time_end': self.dataset.time_end,
             'platform': self.dataset.platform,
+            'cloudcover': self.dataset.cloudcover,
             'instrument': self.dataset.instrument,
             'sensortype': self.dataset.sensortype,
             'off_nadir': self.dataset.illuminationelevationangle

--- a/pycsw/stac/api.py
+++ b/pycsw/stac/api.py
@@ -425,6 +425,37 @@ class STACAPI(API):
             return self.get_exception(400, headers_, 'InvalidParameterValue', msg)
 
         headers_['Accept'] = 'application/json'
+
+        if json_post_data is None:
+            LOGGER.debug('Empty JSON payload')
+            json_post_data = {}
+
+        if 'filter' in json_post_data:
+            LOGGER.debug('Detected filter query parameter')
+            json_post_data = json_post_data.pop('filter')
+
+        if 'bbox' in json_post_data:
+            LOGGER.debug('Detected bbox query parameter')
+            bbox_ = json_post_data.pop('bbox')
+            bbox_ = ','.join([str(b) for b in bbox_])
+            args['bbox'] = bbox_
+
+        if 'limit' in json_post_data:
+            LOGGER.debug('Detected limit query parameter')
+            args['limit'] = json_post_data.pop('limit')
+
+        if 'collections' in json_post_data:
+            LOGGER.debug('Detected limit query parameter')
+            args['collections'] = ','.join(json_post_data.pop('collections'))
+
+        if 'ids' in json_post_data:
+            LOGGER.debug('Detected ids query parameter')
+            args['ids'] = ','.join(json_post_data.pop('ids'))
+
+        if 'intersects' in json_post_data:
+            LOGGER.debug('Detected intersects query parameter')
+            # TODO
+
         headers, status, response = super().items(headers_, json_post_data, args, collection)
 
         response = json.loads(response)

--- a/tests/functionaltests/suites/oarec/test_oarec_functional.py
+++ b/tests/functionaltests/suites/oarec/test_oarec_functional.py
@@ -108,7 +108,7 @@ def test_queryables(config):
     assert content['$id'] == 'http://localhost/pycsw/oarec/collections/metadata:main/queryables'  # noqa
     assert content['$schema'] == 'http://json-schema.org/draft/2019-09/schema'
 
-    assert len(content['properties']) == 14
+    assert len(content['properties']) == 16
 
     assert 'geometry' in content['properties']
     assert content['properties']['geometry']['$ref'] == 'https://geojson.org/schema/Polygon.json'  # noqa

--- a/tests/functionaltests/suites/oarec/test_oarec_virtual_collections_functional.py
+++ b/tests/functionaltests/suites/oarec/test_oarec_virtual_collections_functional.py
@@ -116,7 +116,7 @@ def test_queryables(config_virtual_collections):
     assert content['$id'] == 'http://localhost/pycsw/oarec/collections/metadata:main/queryables'  # noqa
     assert content['$schema'] == 'http://json-schema.org/draft/2019-09/schema'
 
-    assert len(content['properties']) == 14
+    assert len(content['properties']) == 16
 
     assert 'geometry' in content['properties']
     assert content['properties']['geometry']['$ref'] == 'https://geojson.org/schema/Polygon.json'  # noqa

--- a/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
+++ b/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
@@ -134,7 +134,7 @@ def test_queryables(config):
     assert content['$id'] == 'http://localhost/pycsw/oarec/stac/collections/metadata:main/queryables'  # noqa
     assert content['$schema'] == 'http://json-schema.org/draft/2019-09/schema'
 
-    assert len(content['properties']) == 14
+    assert len(content['properties']) == 16
 
     assert 'geometry' in content['properties']
     assert content['properties']['geometry']['$ref'] == 'https://geojson.org/schema/Polygon.json'  # noqa
@@ -156,7 +156,7 @@ def test_items(config):
     record = content['features'][0]
 
     assert record['stac_version'] == '1.0.0'
-    #assert record['collection'] == 'S2MSI2A'
+    # assert record['collection'] == 'S2MSI2A'
 
     for feature in content['features']:
         if feature.get('geometry') is not None:
@@ -283,6 +283,89 @@ def test_items(config):
     content = json.loads(api.items({}, None, {'off_nadir': '3.8'})[2])
     assert len(content['features']) == 1
     assert content['features'][0]['properties']['view:off_nadir'] == 3.8
+
+    cql_json = {
+        'filter-lang': 'cql2-json',
+        'filter': {
+            'op': '=',
+            'args': [{
+                'property': 'parentidentifier'
+                },
+                'S2MSI1C']
+        }
+    }
+
+    content = json.loads(api.items({}, cql_json, {})[2])
+    assert content['numberMatched'] == 12
+
+    cql_json = {
+        'filter-lang': 'cql2-json',
+        'filter': {
+            'op': 'and',
+            'args': [
+                {
+                    'op': 'in',
+                    'args': [
+                        {
+                            'property': 'parentidentifier'
+                        },
+                        [
+                            'ARD_S3',
+                            'S3SLSTR'
+                        ]
+                    ]
+                }
+            ]
+        }
+    }
+
+    content = json.loads(api.items({}, cql_json, {})[2])
+    assert content['numberMatched'] == 0
+
+    cql_json = {
+        'filter-lang': 'cql2-json',
+        'filter': {
+            'op': 'and',
+            'args': [
+                {
+                    'op': 'in',
+                    'args': [
+                        {
+                            'property': 'parentidentifier'
+                        },
+                        [
+                            'foo',
+                            'sentinel-2-l2a'
+                        ]
+                    ]
+                }
+            ]
+        }
+    }
+
+    content = json.loads(api.items({}, cql_json, {})[2])
+    assert content['numberMatched'] == 2
+
+    cql_json = {
+        'filter-lang': 'cql2-json',
+        'filter': {
+            'op': 'and',
+            'args': [
+                {
+                    'op': '<=',
+                    'args': [
+                        {
+                            'property': 'date_creation'
+                        },
+                        '2025-12-15'
+                    ]
+                }
+            ]
+        }
+    }
+
+    content = json.loads(api.items({}, cql_json, {})[2])
+    assert content['numberMatched'] == 2
 
 
 def test_item(config):


### PR DESCRIPTION
# Overview
This PR handles the nuance between parsing CQL2 JSON in OGC API - Records (entire JSON payload) vs. STAC API mode (`filter` property of JSON payload).

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
