### PR TITLE
housekeeping updates

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -29,7 +29,7 @@
 #
 # =================================================================
 
-from datetime import datetime
+from datetime import datetime, UTC
 import json
 import logging
 from operator import itemgetter
@@ -913,7 +913,7 @@ class API:
                     'hreflang': self.config['server']['language']
                 })
 
-        response['timeStamp'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        response['timeStamp'] = datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
         if headers_['Content-Type'] == 'text/html':
             response['title'] = self.config['metadata']['identification']['title']

--- a/pycsw/ogc/pubsub/__init__.py
+++ b/pycsw/ogc/pubsub/__init__.py
@@ -28,7 +28,7 @@
 #
 # =================================================================
 
-from datetime import datetime
+from datetime import datetime, UTC
 import json
 import uuid
 from typing import Union
@@ -87,7 +87,7 @@ def generate_ogc_cloudevent(type_: str, media_type: str,
         'source': 'TODO',
         'subject': subject,
         'id': str(uuid.uuid4()),
-        'time': datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'time': datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ'),
         'datacontenttype': media_type,
         # 'dataschema': 'TODO',
         'data': data2

--- a/pycsw/plugins/profiles/iso19115p3/iso19115p3.py
+++ b/pycsw/plugins/profiles/iso19115p3/iso19115p3.py
@@ -357,8 +357,8 @@ class ISO19115p3(profile.Profile):
             try:
                 val = util.getqattr(result, queryables['mdb:ResourceLanguage']['dbcol'])
             except Exception as e:
-                print(f"{queryables=}")
-                print("exc=", e)
+                LOGGER.error(f"{queryables=}")
+                LOGGER.error("exc=", e)
             if val is None:
                 val = util.getqattr(result, queryables['mdb:Language']['dbcol'])
             lang_code = build_path(node,['mdb:defaultLocale', 'lan:PT_Locale', 'lan:language', 'lan:LanguageCode'], self.namespaces)
@@ -466,7 +466,7 @@ class ISO19115p3(profile.Profile):
                             # Organisation address
                             self._write_contact_address(ci_resp, ci_contact, **contact)
                     except Exception as err:
-                        print(f"failed to parse contacts json of {cjson}: {err}")
+                        LOGGER.error(f"failed to parse contacts json of {cjson}: {err}")
 
             # Creation date for record
             val = util.getqattr(result, queryables['mdb:Modified']['dbcol'])


### PR DESCRIPTION
# Overview
This PR adds some housekeeping to fix a warning on `datetime` use of UTC when creating datetime objects, as well as removing some print statements.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines