### PR TITLE
Add prev/next buttons navigation support for individual items

### DIFF
--- a/pycsw/templates/item.html
+++ b/pycsw/templates/item.html
@@ -20,6 +20,14 @@
 <a href="{{ config['server']['url'] }}/collections/{{ data['collection'] }}/items/{{ data['id'] }}">{{ data['id'] }}</a>
 {% endblock %}
 {% block body %}
+{% set nav_links = namespace(prev=None, next=None) %}
+{% for link in data['links'] %}
+  {% if link['rel'] == 'prev' %}
+    {% set nav_links.prev = link['href'] %}
+  {% elif link['rel'] == 'next' %}
+    {% set nav_links.next = link['href'] %}
+  {% endif %}
+{% endfor %}
 
 <section id="item">
 <div class="container-fluid">
@@ -179,6 +187,28 @@
           {% endif %}
         </tbody>
       </table>
+        <div class="d-flex justify-content-between mt-2">
+  <div>
+    {% if nav_links.prev %}
+      <a href="{{ nav_links.prev }}">
+        <button type="button" class="btn btn-sm btn-primary">Prev</button>
+      </a>
+    {% else %}
+      <button type="button" class="btn btn-sm btn-primary" disabled>Prev</button>
+    {% endif %}
+  </div>
+
+  <div>
+    {% if nav_links.next %}
+      <a href="{{ nav_links.next }}">
+        <button type="button" class="btn btn-sm btn-primary">Next</button>
+      </a>
+    {% else %}
+      <button type="button" class="btn btn-sm btn-primary" disabled>Next</button>
+    {% endif %}
+  </div>
+
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Related to #974 
While browsing individual items, it’s currently not easy to move to the previous or next record without going back to the items list.

This PR improves the HTML item view by adding Previous and Next navigation buttons below the item details table. The buttons reuse the existing pagination links already included in the response (rel="prev" / rel="next"), so no new pagination logic is introduced.

Added Prev / Next buttons to the item HTML page
Uses existing pagination metadata
Does not affect JSON output or API behavior

This makes browsing records more intuitive while keeping the backend behavior unchanged.

I confirm that my contributions to pycsw are compatible with the pycsw license guidelines.