### PR TITLE
STAC API: fix sortby handling in POST mode (#1200)

### DIFF
--- a/pycsw/stac/api.py
+++ b/pycsw/stac/api.py
@@ -446,8 +446,14 @@ class STACAPI(API):
             })
 
         if 'limit' in json_post_data2:
-            LOGGER.debug('Detected limit query parameter')
+            LOGGER.debug('Detected limit parameter')
             args['limit'] = json_post_data2.pop('limit')
+
+        if 'sortby' in json_post_data2:
+            LOGGER.debug('Detected sortby parameter')
+            args['sortby'] = json_post_data2['sortby'][0]['field']
+            if json_post_data2['sortby'][0].get('direction', 'asc') == 'desc':
+                args['sortby'] = f"-{args['sortby']}"
 
         if 'collections' in json_post_data2:
             LOGGER.debug('Detected collections query parameter')

--- a/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
+++ b/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
@@ -791,6 +791,31 @@ def test_items(config):
     content = json.loads(api.items({}, cql_json, {})[2])
     assert content['numberMatched'] == 1
 
+    cql_json = {
+        'filter-lang': 'cql2-json',
+        'filter': {
+            'op': 'and',
+            'args': [
+                {
+                    'op': '=',
+                    'args': [
+                        {
+                            'property': 'instrument'
+                        },
+                        'msi'
+                    ]
+                }
+            ]
+        },
+        'sortby': [{'field': 'datetime', 'direction': 'asc'}]
+    }
+
+    content = json.loads(api.items({}, cql_json, {})[2])
+    assert content['features'][0]['id'] == 'S2B_MSIL1C_20190910T095029_N0208_R079_T33TWN_20190910T120910.SAFE'  # noqa
+    cql_json['sortby'][0]['direction'] = 'desc'
+    content = json.loads(api.items({}, cql_json, {})[2])
+    assert content['features'][0]['id'] == 'S2A_MSIL2A_20241128T092331_R093_T34SEJ_20241128T122153'  # noqa
+
 
 def test_item(config):
     api = STACAPI(config)


### PR DESCRIPTION
# Overview
This PR fixes STAC API sortby support in POST mode.
# Related Issue / Discussion
#1200 
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
