### PR TITLE
Add libssl3t64 update fixing CVE-2026-28390

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ LABEL maintainer="massimods@met.no,aheimsbakk@met.no,tommkralidis@gmail.com,gcpp
 ARG BUILD_DEV_IMAGE="false"
 
 RUN apt-get update --yes && \
-    apt-get install --yes --no-install-recommends ca-certificates python3-setuptools && \
+    apt-get install --yes --no-install-recommends ca-certificates python3-setuptools libssl3t64 && \
     rm -rf /var/lib/apt/lists/*
 
 RUN adduser --uid 1000 --gecos '' --disabled-password pycsw


### PR DESCRIPTION
# Overview

Add libssl3t64 update fixing CVE-2026-28390

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
