### PR TITLE
attach runtime config as blueprint attribute

### DIFF
--- a/pycsw/wsgi_flask.py
+++ b/pycsw/wsgi_flask.py
@@ -50,9 +50,11 @@ BLUEPRINT = Blueprint('pycsw', __name__, static_folder=STATIC,
                       static_url_path='/static')
 
 api_ = API(APP.config['PYCSW_CONFIG'])
+
 with open(os.getenv('PYCSW_CONFIG'), encoding='utf8') as fh:
     stacapi = STACAPI(yaml_load(fh))
 
+BLUEPRINT.config = api_.config
 
 def get_api_type(urlpath):
     """


### PR DESCRIPTION
# Overview
This PR adds the pycsw runtime configuration to the Flask blueprint as a means to access from [pycsw-auth](https://github.com/geopython/pycsw-auth) when generating OpenAPI/Swagger for pycsw-auth.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
