### PR TITLE
update distributedsearch configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ LABEL maintainer="massimods@met.no,aheimsbakk@met.no,tommkralidis@gmail.com,gcpp
 ARG BUILD_DEV_IMAGE="false"
 
 RUN apt-get update --yes && \
-    apt-get install --yes --no-install-recommends ca-certificates python3-setuptools libssl3t64 && \
+    apt-get install --yes --no-install-recommends ca-certificates python3-setuptools libcap2 libssl3t64 && \
     rm -rf /var/lib/apt/lists/*
 
 RUN adduser --uid 1000 --gecos '' --disabled-password pycsw

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ LABEL maintainer="massimods@met.no,aheimsbakk@met.no,tommkralidis@gmail.com,gcpp
 ARG BUILD_DEV_IMAGE="false"
 
 RUN apt-get update --yes && \
-    apt-get install --yes --no-install-recommends ca-certificates python3-setuptools libcap2 libssl3t64 && \
+    apt-get install --yes --no-install-recommends ca-certificates python3-setuptools libcap2 libssl3t64 libsystemd0 && \
     rm -rf /var/lib/apt/lists/*
 
 RUN adduser --uid 1000 --gecos '' --disabled-password pycsw

--- a/default-sample.yml
+++ b/default-sample.yml
@@ -54,21 +54,23 @@ logging:
 profiles:
     - apiso
 
-federatedcatalogues:
-    - id: arctic-sdi-csw
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: pycsw-cite-demo
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      uresultsrl: https://demo.pycsw.org/cite
-    - id: fedcat03
-      type: STAC-API
-      title: Copernicus Data Space Ecosystem (CDSE) asset-level STAC catalogue
-      url: https://stac.dataspace.copernicus.eu/v1
-      collections:
-          - daymet-annual-pr
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: arctic-sdi-csw
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: pycsw-cite-demo
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          uresultsrl: https://demo.pycsw.org/cite
+        - id: fedcat03
+          type: STAC-API
+          title: Copernicus Data Space Ecosystem (CDSE) asset-level STAC catalogue
+          url: https://stac.dataspace.copernicus.eu/v1
+          collections:
+              - daymet-annual-pr
 
 manager:
     transactions: false

--- a/docker/compose/pycsw.yml
+++ b/docker/compose/pycsw.yml
@@ -51,11 +51,12 @@ logging:
 profiles:
     - apiso
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
+distributedsearch:
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
 
 manager:
     transactions: false

--- a/docker/helm/values.yaml
+++ b/docker/helm/values.yaml
@@ -47,11 +47,12 @@ pycsw:
       # logfile: /tmp/pycsw.log
     profiles:
       - apiso
-    # federatedcatalogues:
-    #  - id: fedcat01
-    #    type: CSW 
-    #    title: Arctic SDI 
-    #    url: https://catalogue.arctic-sdi.org/csw
+    # distributedsearch:
+    #     catalogues:
+    #         - id: fedcat01
+    #           type: CSW 
+    #           title: Arctic SDI 
+    #           url: https://catalogue.arctic-sdi.org/csw
     manager:
       transactions: "false"
       allowed_ips:

--- a/docker/kubernetes/pycsw-configmap.yaml
+++ b/docker/kubernetes/pycsw-configmap.yaml
@@ -56,11 +56,12 @@ data:
     profiles:
         - apiso
     
-    federatedcatalogues:
-        - id: fedcat01
-          type: CSW 
-          title: Arctic SDI 
-          url: https://catalogue.arctic-sdi.org/csw
+    distributedsearch:
+        catalogues:
+            - id: fedcat01
+              type: CSW 
+              title: Arctic SDI 
+              url: https://catalogue.arctic-sdi.org/csw
     
     manager:
         transactions: false

--- a/docker/pycsw.yml
+++ b/docker/pycsw.yml
@@ -51,11 +51,12 @@ logging:
 profiles:
     - apiso
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
+distributedsearch:
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
 
 manager:
     transactions: false

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -16,7 +16,7 @@ pycsw's runtime configuration is defined by ``default.yml``.  pycsw ships with a
 - **level**: the logging level (see https://docs.python.org/library/logging.html#logging-levels)
 - **logfile**: the full file path to the logfile
 - **ogc_schemas_base**: base URL of OGC XML schemas tree file structure (default is http://schemas.opengis.net)
-- **federatedcatalogues**: arrray of distributed catalogue endpoints to be used for distributed searching, if requested by the client (see :ref:`distributedsearching`)
+- **distributedsearch**: distributed catalogue endpoints to be used for distributed searching, if requested by the client (see :ref:`distributedsearching`)
 - **pretty_print**: whether to pretty print the output (``true`` or ``false``).  Default is ``false``
 - **gzip_compresslevel**: gzip compression level, lowest is ``1``, highest is ``9``.  Default is off.  **NOTE**: if gzip compression is already enabled via your web server, do not enable this directive (or else the server will try to compress the response twice, resulting in degraded performance)
 - **domainquerytype**: for GetDomain operations, how to output domain values.  Accepted values are ``list`` and ``range`` (min/max). Default is ``list``

--- a/docs/distributedsearching.rst
+++ b/docs/distributedsearching.rst
@@ -15,7 +15,7 @@ Distributed Searching
 CSW 2 / 3
 ---------
 
-pycsw has the ability to perform distributed searching against other CSW servers.  Distributed searching is disabled by default; to enable, ``federatedcatalogues`` must be set.  A CSW client must issue a GetRecords request with ``csw:DistributedSearch`` specified, along with an optional ``hopCount`` attribute (see subclause 10.8.4.13 of the CSW specification).  When enabled, pycsw will search all specified catalogues and return a unified set of search results to the client.  Due to the distributed nature of this functionality, requests will take extra time to process compared to queries against the local repository.
+pycsw has the ability to perform distributed searching against other CSW servers.  Distributed searching is disabled by default; to enable, ``distributedsearch`` must be set.  A CSW client must issue a GetRecords request with ``csw:DistributedSearch`` specified, along with an optional ``hopCount`` attribute (see subclause 10.8.4.13 of the CSW specification).  When enabled, pycsw will search all specified catalogues and return a unified set of search results to the client.  Due to the distributed nature of this functionality, requests will take extra time to process compared to queries against the local repository.
 
 Scenario: Federated Search
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,19 +56,21 @@ in the CSW-all configuration:
 
 .. code-block:: yaml
 
-  federatedcatalogues:
-      - id: fedcat01
-        type: CSW
-        title: Federated catalogue 1
-        url: http://localhost/pycsw/csw.py?config=CSW-1.yml
-      - id: fedcat02
-        type: CSW
-        title: Federated catalogue 2
-        url: http://localhost/pycsw/csw.py?config=CSW-2.yml
-      - id: fedcat03
-        type: CSW
-        title: Federated catalogue 3
-        url: http://localhost/pycsw/csw.py?config=CSW-3.yml
+  distributedsearch:
+      merge_results: false
+      catalogues:
+          - id: fedcat01
+            type: CSW
+            title: Federated catalogue 1
+            url: http://localhost/pycsw/csw.py?config=CSW-1.yml
+          - id: fedcat02
+            type: CSW
+            title: Federated catalogue 2
+            url: http://localhost/pycsw/csw.py?config=CSW-2.yml
+          - id: fedcat03
+            type: CSW
+            title: Federated catalogue 3
+            url: http://localhost/pycsw/csw.py?config=CSW-3.yml
  
 At which point a CSW client request to CSW-all with ``distributedsearch=TRUE``, while specifying an optional ``hopCount``.  Query network topology:
 
@@ -101,23 +103,29 @@ Experimental support for distibuted searching is available in pycsw's OGC API - 
 
 .. note::
 
-   The ``federatedcatalogues`` directives must point to an OGC API - Records **collections** endpoint.
+   The ``distributedsearch.catalogues`` directives must point to an OGC API - Records **collections** endpoint.
 
 .. code-block:: yaml
 
-  federatedcatalogues:
-      - id: fedcat01
-        type: OARec
-        title: Federated catalogue 1
-        url: https://example.org/collections/collection1
-      - id: fedcat02
-        type: OARec
-        title: Federated catalogue 2
-        url: https://example.org/collections/collection2
+  distributedsearch
+      catalogues:
+          - id: fedcat01
+            type: OARec
+            title: Federated catalogue 1
+            url: https://example.org/collections/collection1
+          - id: fedcat02
+            type: OARec
+            title: Federated catalogue 2
+            url: https://example.org/collections/collection2
  
 With the above configured, a distributed search can be invoked as follows:
 
 http://localhost/collections/metadata:main/items?distributedSearch=true
+
+Merging results
+^^^^^^^^^^^^^^^
+
+When `distributedsearch.merge_results` exists and is set to ``true``, pycsw will merge all results in ``federatedSearchResults``.  To prevent identifier collision, merged federated search results will have identifiers prefixed by their catalogue ``id`` (as defined in ``distributedsearch.catalogues[*].id``.  In addition, a ``federatedCatalogueId`` property is added to the feature with the catalogue id.
 
 STAC API
 --------
@@ -126,17 +134,18 @@ Experimental support for distibuted searching is available in pycsw's STAC API s
 
 .. note::
 
-   The ``federatedcatalogues`` directives must point to a STAC API endpoint.
+   The ``distributedsearch.catalogues`` directives must point to a STAC API endpoint.
 
 .. code-block:: yaml
 
-  federatedcatalogues:
-    - id: fedcat03
-      type: STAC-API
-      title: Copernicus Data Space Ecosystem (CDSE) asset-level STAC catalogue
-      url: https://stac.dataspace.copernicus.eu/v1
-      collections:
-          - daymet-annual-pr
+  distributedsearch:
+      catalogues:
+          - id: fedcat03
+            type: STAC-API
+            title: Copernicus Data Space Ecosystem (CDSE) asset-level STAC catalogue
+            url: https://stac.dataspace.copernicus.eu/v1
+            collections:
+                - daymet-annual-pr
 
 
 .. note::
@@ -147,5 +156,11 @@ Experimental support for distibuted searching is available in pycsw's STAC API s
 With the above configured, a distributed search can be invoked as follows:
 
 http://localhost/stac/search?distributedSearch=true
+
+Merging results
+^^^^^^^^^^^^^^^
+
+Merging behaviour is implemented in the same manner as OGC API - Records support.
+
 
 .. _`OGC API - Records - Part 4: Federated Search`: https://github.com/opengeospatial/ogcapi-records/blob/master/extensions/federated-search/document.adoc

--- a/pycsw/core/admin.py
+++ b/pycsw/core/admin.py
@@ -618,7 +618,9 @@ def cli_migrate_config(ctx, config, verbosity):
             'inspire': {}
         },
         'profiles': [],
-        'federatedcatalogues': [],
+        'distributedsearch': {
+            'catalogues': []
+        },
         'repository': {}
     }
 
@@ -634,7 +636,7 @@ def cli_migrate_config(ctx, config, verbosity):
         elif name == 'federatedcatalogues':
             dict_[name] = []
             for count, fc in enumerate(value.split(',')):
-                dict_[name].append({'id': f'fedcat{count}', 'url': fc})
+                dict_['distributedsearch']['catalogues'].append({'id': f'fedcat{count}', 'url': fc})
         else:
             dict_['server'][name] = get_typed_value(value)
 

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -483,7 +483,7 @@ class API:
             'hreflang': self.config['server']['language']
         }]
 
-        if collection == 'metadata:main' and 'federatedcatalogues' in self.config:
+        if collection == 'metadata:main' and 'distributedsearch' in self.config:
             LOGGER.debug('Adding federated catalogues')
             response['links'].append({
                 'rel': 'http://www.opengis.net/def/rel/ogc/1.0/federatedCatalogues',
@@ -818,7 +818,10 @@ class API:
         distributed = str2bool(args.get('distributedsearch', False))
 
         if distributed:
-            for fc in self.config.get('federatedcatalogues', []):
+            distributed_search = self.config.get('distributedsearch', {})
+            merge_results = distributed_search.get('merge_results', False)
+
+            for fc in distributed_search.get('catalogues', []):
                 if fc['type'] != 'OARec':
                     LOGGER.debug(f"Federated catalogue type {fc['type']} not supported; skipping")
                     continue
@@ -833,9 +836,18 @@ class API:
                     args.pop('distributedsearch')
                     fc_results = w.collection_items(fc_collection, **args)
                     for feature in fc_results['features']:
+                        if merge_results:
+                            feature['id'] = f"{fc['id']}::{feature['id']}"
+                            feature['federatedCatalogueId'] = fc['id']
                         response['federatedSearchResults'][fc['id']]['features'].append(feature)
                 except Exception as err:
                     LOGGER.warning(err)
+
+            if merge_results:
+                LOGGER.debug('Merging federated search results into main items')
+                fsrs = response.pop('federatedSearchResults', None)
+                for key, value in fsrs.items():
+                    response['features'].extend(value['features'])
 
         LOGGER.debug('Creating links')
 
@@ -970,7 +982,7 @@ class API:
             distributed = str2bool(args.get('distributed', False))
 
             if distributed:
-                for fc in self.config.get('federatedcatalogues', []):
+                for fc in self.config.get('distributedsearch', {}).get('catalogues', []):
                     if fc['type'] != 'OARec':
                         LOGGER.debug(f"Federated catalogue type {fc['type']} not supported; skipping")
                         continue
@@ -1180,7 +1192,7 @@ class API:
         fedcats = []
 
         if collection == 'metadata:main':
-            for fedcat_ in self.config.get('federatedcatalogues', []):
+            for fedcat_ in self.config.get('distributedsearch', {}).get('catalogues', []):
                 if fedcat_['type'] == 'OARec':
                     fedcats.append(fedcat_)
 
@@ -1213,7 +1225,7 @@ class API:
         fedcat = None
 
         if collection == 'metadata:main':
-            fedcats = self.config.get('federatedcatalogues')
+            fedcats = self.config.get('distributedsearch', {}).get('catalogues', [])
             for fedcat_ in fedcats:
                 if fedcat_['id'] == catalogue and fedcat_['type'] == 'OARec':
                     fedcat = fedcat_

--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -825,7 +825,7 @@ class Csw2(object):
 
         hopcount = int(self.parent.kvp.get('hopcount', 2)) - 1
 
-        if ('federatedcatalogues' in self.parent.config and
+        if ('distributedsearch' in self.parent.config and
                 self.parent.kvp.get('distributedsearch') and
                 hopcount > 0):
 
@@ -833,7 +833,7 @@ class Csw2(object):
 
             from owslib.csw import CatalogueServiceWeb
             from owslib.ows import ExceptionReport
-            for fedcat in self.parent.config.get('federatedcatalogues', []):
+            for fedcat in self.parent.config.get('distributedsearch', {}).get('catalogues', []):
                 if fedcat['type'] != 'CSW':
                     LOGGER.debug(f"Federated catalogue type {fedcat['type']} not supported; skipping")
                     continue

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -974,7 +974,7 @@ class Csw3(object):
 
         hopcount = int(self.parent.kvp.get('hopcount', 2)) - 1
 
-        if ('federatedcatalogues' in self.parent.config and
+        if ('distributedsearch' in self.parent.config and
                 self.parent.kvp.get('distributedsearch') and
                 hopcount > 0):
 
@@ -982,7 +982,7 @@ class Csw3(object):
 
             from owslib.csw import CatalogueServiceWeb
             from owslib.ows import ExceptionReport
-            for fedcat in self.parent.config.get('federatedcatalogues', []):
+            for fedcat in self.parent.config.get('distributedsearch', {}).get('catalogues', []):
                 if fedcat['type'] != 'CSW':
                     LOGGER.debug(f"Federated catalogue type {fedcat['type']} not supported; skipping")
                     continue

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -323,12 +323,12 @@ class Csw(object):
             ops['GetDomain'] = self.context.gen_domains()
 
         # generate distributed search model, if specified in config
-        if 'federatedcatalogues' in self.config:
+        if 'distributedsearch' in self.config:
             LOGGER.info('Configuring distributed search')
 
             constraints['FederatedCatalogues'] = {'values': []}
 
-            for fedcat in self.config['federatedcatalogues']:
+            for fedcat in self.config['distributedsearch'].get('catalogues', []):
                 LOGGER.debug('federated catalogue: %s', fedcat)
                 if fedcat['type'] == 'CSW':
                     constraints['FederatedCatalogues']['values'].append(fedcat['url'])

--- a/pycsw/stac/api.py
+++ b/pycsw/stac/api.py
@@ -424,7 +424,7 @@ class STACAPI(API):
         json_post_data2 = {}
         distributed_search_args = {}
 
-        distributed = str2bool(args.get('distributedSearch', False))
+        distributed = str2bool(args.get('distributedsearch', False))
 
         if distributed:
             LOGGER.debug('Setting distributed search args')
@@ -619,7 +619,10 @@ class STACAPI(API):
             links2.append(link)
 
         if distributed:
-            for fc in self.config.get('federatedcatalogues', []):
+            distributed_search = self.config.get('distributedsearch', {})
+            merge_results = distributed_search.get('merge_results', False)
+
+            for fc in distributed_search.get('catalogues', []):
                 distributed_search_args2 = deepcopy(distributed_search_args)
                 if 'collections' in fc:
                     if 'collections' in distributed_search_args2:
@@ -646,10 +649,18 @@ class STACAPI(API):
                     LOGGER.debug(f'Querying STAC API search: {url}')
                     stac_search_results = requests.get(url, params=distributed_search_args2).json()
                     for feature in stac_search_results['features']:
+                        if merge_results:
+                            feature['id'] = f"{fc['id']}::{feature['id']}"
+                            feature['federatedCatalogueId'] = fc['id']
                         response2['federatedSearchResults'][fc['id']]['features'].append(feature)
                 except Exception as err:
                     LOGGER.warning(err)
 
+            if merge_results:
+                LOGGER.debug('Merging federated search results into main items')
+                fsrs = response.pop('federatedSearchResults', None)
+                for key, value in fsrs.items():
+                    response2['features'].extend(value['features'])
 
         response2['links'] = links2
 

--- a/pycsw/templates/collection.html
+++ b/pycsw/templates/collection.html
@@ -35,7 +35,7 @@
         <td>
            <a title="items" href="{{ config['server']['url'] }}/collections/{{ data.id }}/items">items</a>
            <a title="queryables" href="{{ config['server']['url'] }}/collections/{{ data.id }}/queryables">queryables</a>
-           {% if data.id == 'metadata:main' and config['federatedcatalogues'] %}
+           {% if data.id == 'metadata:main' and config['distributedsearch'] %}
            <a title="federated catalogs" href="{{ config['server']['url'] }}/collections/{{ data.id }}/federatedCatalogs">federated catalogs</a>
            {% endif %}
         </td>

--- a/pycsw/templates/collections.html
+++ b/pycsw/templates/collections.html
@@ -34,7 +34,7 @@
         <td>
            <a title="items" href="{{ config['server']['url'] }}/collections/{{ col.id }}/items">items</a>
            <a title="queryables" href="{{ config['server']['url'] }}/collections/{{ col.id }}/queryables">queryables</a>
-           {% if col.id == 'metadata:main' and config['federatedcatalogues'] %}
+           {% if col.id == 'metadata:main' and config['distributedsearch'] %}
            <a title="federated catalogs" href="{{ config['server']['url'] }}/collections/{{ col.id }}/federatedCatalogs">federated catalogs</a>
            {% endif %}
         </td>

--- a/tests/functionaltests/suites/apiso-inspire/default.yml
+++ b/tests/functionaltests/suites/apiso-inspire/default.yml
@@ -44,15 +44,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/apiso/default.yml
+++ b/tests/functionaltests/suites/apiso/default.yml
@@ -44,15 +44,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/atom/default.yml
+++ b/tests/functionaltests/suites/atom/default.yml
@@ -41,15 +41,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/cite/default.yml
+++ b/tests/functionaltests/suites/cite/default.yml
@@ -41,15 +41,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: true

--- a/tests/functionaltests/suites/csw30/default.yml
+++ b/tests/functionaltests/suites/csw30/default.yml
@@ -41,11 +41,13 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW 
-      title: Demo of gisdata GitHub repository
-      url: https://demo.pycsw.org/gisdata/csw
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW 
+          title: Demo of gisdata GitHub repository
+          url: https://demo.pycsw.org/gisdata/csw
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/default/default.yml
+++ b/tests/functionaltests/suites/default/default.yml
@@ -41,11 +41,13 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Demo of gisdata GitHub repository
-      url: https://demo.pycsw.org/gisdata/csw
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Demo of gisdata GitHub repository
+          url: https://demo.pycsw.org/gisdata/csw
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/dif/default.yml
+++ b/tests/functionaltests/suites/dif/default.yml
@@ -41,15 +41,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/duplicatefileid/default.yml
+++ b/tests/functionaltests/suites/duplicatefileid/default.yml
@@ -41,15 +41,16 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-#federatedcatalogues:
-#    - id: fedcat01
-#      type: CSW
-#      title: Arctic SDI
-#      url: https://catalogue.arctic-sdi.org/csw
-#    - id: fedcat02
-#      type: OARec
-#      title: pycsw OGC CITE demo and Reference Implementation
-#      url: https://demo.pycsw.org/cite/collections/metadata:main
+#distributedsearch:
+#    catalogues
+#        - id: fedcat01
+#          type: CSW
+#          title: Arctic SDI
+#          url: https://catalogue.arctic-sdi.org/csw
+#        - id: fedcat02
+#          type: OARec
+#          title: pycsw OGC CITE demo and Reference Implementation
+#          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/ebrim/default.yml
+++ b/tests/functionaltests/suites/ebrim/default.yml
@@ -44,15 +44,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/fgdc/default.yml
+++ b/tests/functionaltests/suites/fgdc/default.yml
@@ -41,15 +41,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/gm03/default.yml
+++ b/tests/functionaltests/suites/gm03/default.yml
@@ -41,15 +41,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/harvesting/default.yml
+++ b/tests/functionaltests/suites/harvesting/default.yml
@@ -44,15 +44,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: true

--- a/tests/functionaltests/suites/idswithpaths/default.yml
+++ b/tests/functionaltests/suites/idswithpaths/default.yml
@@ -41,15 +41,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-#federatedcatalogues:
-#    - id: fedcat01
-#      type: CSW
-#      title: Arctic SDI
-#      url: https://catalogue.arctic-sdi.org/csw
-#    - id: fedcat02
-#      type: OARec
-#      title: pycsw OGC CITE demo and Reference Implementation
-#      url: https://demo.pycsw.org/cite/collections/metadata:main
+#distributedsearch:
+#    merge_results: false    
+#    catalogues:
+#        - id: fedcat01
+#          type: CSW
+#          title: Arctic SDI
+#          url: https://catalogue.arctic-sdi.org/csw
+#        - id: fedcat02
+#          type: OARec
+#          title: pycsw OGC CITE demo and Reference Implementation
+#          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/iso19115p3/default.yml
+++ b/tests/functionaltests/suites/iso19115p3/default.yml
@@ -44,15 +44,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/manager/default.yml
+++ b/tests/functionaltests/suites/manager/default.yml
@@ -44,15 +44,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: true

--- a/tests/functionaltests/suites/oaipmh/default.yml
+++ b/tests/functionaltests/suites/oaipmh/default.yml
@@ -44,15 +44,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/opensearcheo/default.yml
+++ b/tests/functionaltests/suites/opensearcheo/default.yml
@@ -44,15 +44,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-#federatedcatalogues:
-#    - id: fedcat01
-#      type: CSW
-#      title: Arctic SDI
-#      url: https://catalogue.arctic-sdi.org/csw
-#    - id: fedcat02
-#      type: OARec
-#      title: pycsw OGC CITE demo and Reference Implementation
-#      url: https://demo.pycsw.org/cite/collections/metadata:main
+#distributedsearch:
+#    merge_results: false    
+#    catalogues:
+#        - id: fedcat01
+#          type: CSW
+#          title: Arctic SDI
+#          url: https://catalogue.arctic-sdi.org/csw
+#        - id: fedcat02
+#          type: OARec
+#          title: pycsw OGC CITE demo and Reference Implementation
+#          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/repofilter/default.yml
+++ b/tests/functionaltests/suites/repofilter/default.yml
@@ -41,15 +41,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/sru/default.yml
+++ b/tests/functionaltests/suites/sru/default.yml
@@ -41,15 +41,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/stablesort/default.yml
+++ b/tests/functionaltests/suites/stablesort/default.yml
@@ -38,15 +38,17 @@ server:
 logging:
     level: DEBUG
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/utf-8/default.yml
+++ b/tests/functionaltests/suites/utf-8/default.yml
@@ -41,15 +41,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false

--- a/tests/functionaltests/suites/xslt/default.yml
+++ b/tests/functionaltests/suites/xslt/default.yml
@@ -44,15 +44,17 @@ logging:
     level: DEBUG
 #    logfile: /tmp/pycsw.log
 
-federatedcatalogues:
-    - id: fedcat01
-      type: CSW
-      title: Arctic SDI
-      url: https://catalogue.arctic-sdi.org/csw
-    - id: fedcat02
-      type: OARec
-      title: pycsw OGC CITE demo and Reference Implementation
-      url: https://demo.pycsw.org/cite/collections/metadata:main
+distributedsearch:
+    merge_results: false
+    catalogues:
+        - id: fedcat01
+          type: CSW
+          title: Arctic SDI
+          url: https://catalogue.arctic-sdi.org/csw
+        - id: fedcat02
+          type: OARec
+          title: pycsw OGC CITE demo and Reference Implementation
+          url: https://demo.pycsw.org/cite/collections/metadata:main
 
 manager:
     transactions: false


### PR DESCRIPTION
# Overview
This PR updates federated search configuration to allow for merging of federated results (on `.../item?distributedSearch=true` as part of the mean `features` array (vs. the `federatedSearchResults` array [default]) by:

- renaming `federatedcatalogues` (array) in to `distributedsearch` (object) with a `merge_results` (boolean, default `false` ) directive.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines