### PR TITLE
add pycsw-admin.py alias to Docker setup (#1215)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,9 @@ COPY --chown=pycsw . .
 COPY docker/pycsw.yml ${PYCSW_CONFIG}
 COPY docker/entrypoint.py /usr/local/bin/entrypoint.py
 
-RUN /venv/bin/pip3 install -e . --config-settings editable_mode=strict
+RUN /venv/bin/pip3 install -e . --config-settings editable_mode=strict && \
+    echo 'alias pycsw-admin.py="/venv/bin/pycsw-admin.py"' >> /etc/bash.bashrc
+
 
 WORKDIR /home/pycsw
 


### PR DESCRIPTION
# Overview
This PR adds an alias for `pycsw-admin.py` as part of the Docker setup.
# Related Issue / Discussion
Fixes #1215 
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
