### PR TITLE
Dockerfile: use Magnar's pygeofilter fork (fixes-05-2026) for Solr/MET Norway dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ LABEL maintainer="massimods@met.no,aheimsbakk@met.no,tommkralidis@gmail.com,gcpp
 ARG BUILD_DEV_IMAGE="false"
 
 RUN apt-get update --yes && \
-    apt-get install --yes --no-install-recommends ca-certificates python3-setuptools libcap2 libssl3t64 libsystemd0 && \
+    apt-get install --yes --no-install-recommends ca-certificates python3-setuptools libcap2 libssl3t64 libsystemd0 git && \
     rm -rf /var/lib/apt/lists/*
 
 RUN adduser --uid 1000 --gecos '' --disabled-password pycsw
@@ -76,7 +76,7 @@ COPY --chown=pycsw . .
 COPY docker/pycsw.yml ${PYCSW_CONFIG}
 COPY docker/entrypoint.py /usr/local/bin/entrypoint.py
 
-RUN /venv/bin/pip3 install --force-reinstall https://github.com/geopython/pygeofilter/archive/main.zip && \
+RUN /venv/bin/pip3 install --force-reinstall git+https://github.com/magnarem/pygeofilter@fixes-05-2026 && \
     /venv/bin/pip3 install -e . --config-settings editable_mode=strict
 
 WORKDIR /home/pycsw


### PR DESCRIPTION
## Summary

Two small Dockerfile changes needed to build a working image for the MET Norway Solr repository plugin.

### Changes

- **Add `git` to apt deps**: `pip install git+https://...` requires `git` in the container at build time. The previous `main.zip` snapshot install did not need it, but switching to a git-based install does.

- **Use `magnarem/pygeofilter@fixes-05-2026` instead of `geopython/pygeofilter/archive/main.zip`**: Magnar Martinsen's fork contains active fixes for the Solr backend evaluator that are needed for the MET Norway deployment — specifically correct Solr `pdate` date formatting, `equality()`/`in_()` value quoting for identifiers containing colons, and an `and_()` fix. These fixes are being prepared for upstream PR to `geopython/pygeofilter` but are not yet merged.

### Context

The MET Norway Solr plugin (`SolrMETNORepository`) is developed against `geopython/pycsw` `repo-abstract`. The pygeofilter Solr backend has several bugs that affect real-world Solr deployments (bare `YYYY-MM-DD` dates rejected by `pdate` fields, unquoted special characters causing Solr parse errors, `and_()` discarding filter arrays). Magnar's fork collects these fixes while upstream PRs are in progress.

Once the upstream PRs to `geopython/pygeofilter` are merged, this can revert to using the `geopython` package.

## Test plan

- [ ] `docker build -t epinux/pycsw-repo-abstract:latest .`
- [ ] Deploy with `sh update_service.sh test` and verify `https://test.wps.met.no/csw?service=CSW&version=2.0.2&request=GetCapabilities` returns a valid capabilities document