### PR TITLE
update docs on config list elements

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -35,7 +35,7 @@ pycsw's runtime configuration is defined by ``default.yml``.  pycsw ships with a
 **manager**
 
 - **transactions**: whether to enable transactions (``true`` or ``false``).  Default is ``false`` (see :ref:`transactions`)
-- **allowed_ips**: comma delimited list of IP addresses (e.g. 192.168.0.103), wildcards (e.g. 192.168.0.*) or CIDR notations (e.g. 192.168.100.0/24) allowed to perform transactions (see :ref:`transactions`)
+- **allowed_ips**: list of IP addresses (e.g. 192.168.0.103), wildcards (e.g. 192.168.0.*) or CIDR notations (e.g. 192.168.100.0/24) allowed to perform transactions (see :ref:`transactions`)
 - **csw_harvest_pagesize**: when harvesting other CSW servers, the number of records per request to page by (default is 10)
 
 **pubsub**
@@ -94,7 +94,7 @@ pycsw's runtime configuration is defined by ``default.yml``.  pycsw ships with a
 - **filter**: server side database filter to apply as mask to all CSW requests (see :ref:`repofilters`)
 - **max_retries**: max number of retry attempts when connecting to records-repository database
 - **stable_sort**: enables stable sorting by appending an identifier sort as the last sortable. Default is ``false``
-- **facets**: comma-separated list of facetable properties for search results
+- **facets**: list of facetable properties for search results
 
 .. note::
 

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -55,7 +55,7 @@ Your profile plugin class (``FooProfile``) must implement all methods as per ``p
 Enabling Profiles
 -----------------
 
-All profiles are disabled by default.  To specify profiles at runtime, set the ``profiles`` value in the :ref:`configuration` to the name of the package (in the ``pycsw/plugins/profiles`` directory).  To enable multiple profiles, specify as a comma separated value (see :ref:`configuration`).
+All profiles are disabled by default.  To specify profiles at runtime, set the ``profiles`` value in the :ref:`configuration` to the name of the package (in the ``pycsw/plugins/profiles`` directory).  To enable multiple profiles, specify as a list (see :ref:`configuration`).
 
 Testing
 -------


### PR DESCRIPTION
# Overview
This PR fixes documentation to qualify list items reflecting the YAML config (vs. lists via CSV in the previous 2.x configuration)

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my coxntributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
