### PR TITLE
OARec/STAC: add publication date to queryables

### DIFF
--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -161,6 +161,7 @@ class Repository(object):
             'date': self.dataset.date,
             'date_creation': self.dataset.date_creation,
             'date_modified': self.dataset.date_modified,
+            'date_publication': self.dataset.date_publication,
             'datetime': self.dataset.date,
             'time_begin': self.dataset.time_begin,
             'time_end': self.dataset.time_end,

--- a/tests/functionaltests/suites/oarec/test_oarec_functional.py
+++ b/tests/functionaltests/suites/oarec/test_oarec_functional.py
@@ -108,7 +108,7 @@ def test_queryables(config):
     assert content['$id'] == 'http://localhost/pycsw/oarec/collections/metadata:main/queryables'  # noqa
     assert content['$schema'] == 'http://json-schema.org/draft/2019-09/schema'
 
-    assert len(content['properties']) == 19
+    assert len(content['properties']) == 20
 
     assert 'geometry' in content['properties']
     assert content['properties']['geometry']['$ref'] == 'https://geojson.org/schema/Polygon.json'  # noqa

--- a/tests/functionaltests/suites/oarec/test_oarec_virtual_collections_functional.py
+++ b/tests/functionaltests/suites/oarec/test_oarec_virtual_collections_functional.py
@@ -116,7 +116,7 @@ def test_queryables(config_virtual_collections):
     assert content['$id'] == 'http://localhost/pycsw/oarec/collections/metadata:main/queryables'  # noqa
     assert content['$schema'] == 'http://json-schema.org/draft/2019-09/schema'
 
-    assert len(content['properties']) == 19
+    assert len(content['properties']) == 20
 
     assert 'geometry' in content['properties']
     assert content['properties']['geometry']['$ref'] == 'https://geojson.org/schema/Polygon.json'  # noqa

--- a/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
+++ b/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
@@ -134,7 +134,7 @@ def test_queryables(config):
     assert content['$id'] == 'http://localhost/pycsw/oarec/stac/collections/metadata:main/queryables'  # noqa
     assert content['$schema'] == 'http://json-schema.org/draft/2019-09/schema'
 
-    assert len(content['properties']) == 19
+    assert len(content['properties']) == 20
 
     assert 'geometry' in content['properties']
     assert content['properties']['geometry']['$ref'] == 'https://geojson.org/schema/Polygon.json'  # noqa


### PR DESCRIPTION
# Overview
This PR adds `date_publication` as a queryable to OARec and STAC functionality.
# Related Issue / Discussion
#1232
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
