### PR TITLE
Add configurable record_transform hook for post-query record processing

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ pycsw |release| Documentation
    repositories
    outputschemas
    xslt
+   record-transform
    html-templating
    geonode
    hhypermap

--- a/docs/record-transform.rst
+++ b/docs/record-transform.rst
@@ -1,0 +1,194 @@
+.. _record-transform:
+
+Record Transform
+================
+
+pycsw supports a configurable record transform hook that allows post-processing
+of metadata records before they are serialized into any output format.  This
+provides a single, unified intervention point that applies to all supported
+protocols and output formats:
+
+- OGC API - Records (JSON and HTML)
+- OGC API - Records (application/xml)
+- CSW 2.0.2 and CSW 3.0 (XML, all output schemas and profiles)
+
+Common use cases include:
+
+- Removing internal or private keywords before returning records to clients
+- Redacting sensitive field values
+- Normalizing or enriching output fields
+
+Configuration
+-------------
+
+Set ``server.record_transform`` in the pycsw configuration file to the path of
+a Python file or a dotted module name:
+
+.. code-block:: yaml
+
+   server:
+       record_transform: /etc/pycsw/transform.py
+
+The referenced file or module must define a callable named ``record_transform``.
+
+Docker
+------
+
+The transform file can be injected into a container using a bind mount:
+
+.. code-block:: yaml
+
+   # docker-compose.yml
+   services:
+     pycsw:
+       volumes:
+         - ./my_transform.py:/etc/pycsw/transform.py
+
+Writing a transform
+-------------------
+
+The ``record_transform`` callable receives a pycsw record object (a SQLAlchemy
+ORM instance whose attributes correspond to the pycsw core metadata model) and
+must return the same object (optionally modified).
+
+How serialization works determines which fields you need to modify:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 35 30
+
+   * - Output format
+     - Reads from
+     - What to modify
+   * - OGC API JSON
+     - Individual fields
+     - ``record.keywords``, ``record.title``, …
+   * - OGC API HTML
+     - Individual fields
+     - ``record.keywords``, ``record.title``, …
+   * - OGC API ``application/xml``
+     - ``record.xml``
+     - ``record.xml``
+   * - CSW XML
+     - Individual fields (see note)
+     - ``record.keywords``, ``record.title``, …
+   * - CSW JSON
+     - Individual fields
+     - ``record.keywords``, ``record.title``, …
+
+.. note::
+
+   **CSW XML exception:** when ``elementSetName=full`` is requested and
+   ``record.xml`` contains a native ISO format (ISO 19139 or ISO 19115-3),
+   pycsw returns ``record.xml`` directly instead of re-serializing from
+   individual fields.  In that case, modify ``record.xml`` as well to affect
+   those responses.
+
+**Modifying ORM fields**
+
+Changing ORM attributes is sufficient for OGC API JSON, OGC API HTML, and all
+CSW responses, because those serializers read directly from the record object's
+fields:
+
+.. code-block:: python
+
+   # /etc/pycsw/transform.py
+
+   def record_transform(record):
+       """Remove keywords prefixed with '_internal_' from all responses."""
+       if record.keywords:
+           record.keywords = ','.join(
+               kw for kw in record.keywords.split(',')
+               if not kw.strip().startswith('_internal_')
+           )
+       return record
+
+Available record attributes follow the pycsw core metadata model (see
+:ref:`metadata-model-reference`).  Common attributes include ``identifier``,
+``title``, ``abstract``, ``keywords``, ``themes``, ``links``, and
+``contacts``.
+
+**Modifying the raw XML blob**
+
+OGC API ``application/xml`` responses are served directly from ``record.xml``
+— the original XML document as it was ingested — rather than re-serialized
+from ORM fields.  ``record.xml`` may contain ISO 19139, Dublin Core, or any
+other format that was submitted at ingest time.
+
+To filter these responses the transform must also parse and rewrite
+``record.xml`` using the namespace and element structure of the ingested
+format.  The following example handles **ISO 19139** records:
+
+.. code-block:: python
+
+   # /etc/pycsw/transform.py (ISO 19139 example)
+
+   from lxml import etree
+
+   _PREFIXES = ('source:', 'catalog:', 'organisation:', 'transaction:', 'sub_organisation:')
+
+   _NS = {
+       'gmd': 'http://www.isotc211.org/2005/gmd',
+       'gco': 'http://www.isotc211.org/2005/gco',
+   }
+
+   def record_transform(record):
+       # Filter the flat keyword column (OGC API JSON/HTML, CSW XML)
+       if record.keywords:
+           record.keywords = ','.join(
+               kw for kw in record.keywords.split(',')
+               if not kw.strip().startswith(_PREFIXES)
+           )
+
+       # Filter the raw XML blob (OGC API application/xml; CSW ISO full)
+       if record.xml:
+           try:
+               xml_in = record.xml if isinstance(record.xml, bytes) else record.xml.encode('utf-8')
+               root = etree.fromstring(xml_in)
+               for md_kw in root.findall('.//gmd:MD_Keywords', _NS):
+                   for kw_el in md_kw.findall('gmd:keyword', _NS):
+                       cs = kw_el.find('gco:CharacterString', _NS)
+                       if cs is not None and cs.text and cs.text.strip().startswith(_PREFIXES):
+                           md_kw.remove(kw_el)
+                   if not md_kw.findall('gmd:keyword', _NS):
+                       parent = md_kw.getparent()
+                       if parent is not None:
+                           parent.getparent().remove(parent)
+               record.xml = etree.tostring(root, encoding='unicode')
+           except Exception:
+               pass
+
+       return record
+
+For Dublin Core records, keywords are stored in ``dc:subject`` elements and
+the namespace handling must be adapted accordingly.
+
+.. warning::
+
+   **Security and trust model**
+
+   The transform file is executed as Python code with the same OS privileges as
+   the pycsw process.  It has unrestricted access to the filesystem, network,
+   environment variables, and the database.
+
+   pycsw itself never commits the SQLAlchemy session after a read request, so
+   ordinary attribute modifications (``record.keywords = …``) do not persist to
+   the database in normal usage. However, a transform function **can** access
+   the live session via ``sqlalchemy.orm.object_session(record)`` and call
+   ``session.commit()`` explicitly, which **does** write to the database.
+
+   Treat the transform file as trusted administrator code — equivalent to
+   pycsw's own application code.  It must be controlled exclusively by the
+   system administrator and must never be loaded from an untrusted source or
+   influenced by API clients.
+
+Using a dotted module path
+--------------------------
+
+If the transform module is installed as a Python package and is accessible on
+the ``PYTHONPATH``, you may also specify it as a dotted module path:
+
+.. code-block:: yaml
+
+   server:
+       record_transform: mypackage.transforms.record_transform

--- a/pycsw/core/util.py
+++ b/pycsw/core/util.py
@@ -518,6 +518,29 @@ def programmatic_import(target_module: str) -> typing.Optional[typing.Any]:
     return result
 
 
+def load_record_transform(transform_path: str) -> typing.Optional[typing.Callable]:
+    """
+    Load a record transform callable from a file path or dotted module path.
+
+    The referenced module must define a callable named ``record_transform``.
+
+    :param transform_path: path to a Python file or dotted module name
+    :returns: callable, or ``None`` if ``transform_path`` is falsy
+    :raises ValueError: if the module cannot be loaded or lacks ``record_transform``
+    """
+    if not transform_path:
+        return None
+    module = programmatic_import(transform_path)
+    if module is None:
+        raise ValueError(f'Could not load record transform module: {transform_path!r}')
+    func = getattr(module, 'record_transform', None)
+    if func is None or not callable(func):
+        raise ValueError(
+            f"Module {transform_path!r} must define a callable named 'record_transform'"
+        )
+    return func
+
+
 def load_custom_repo_mappings(repository_mappings: str) -> typing.Optional[typing.Dict]:
     imported_mappings_module = programmatic_import(repository_mappings)
     result = None

--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -48,7 +48,7 @@ from pycsw.core import log
 from pycsw.core.config import StaticContext
 from pycsw.core.metadata import parse_record
 from pycsw.core.pygeofilter_evaluate import to_filter
-from pycsw.core.util import bind_url, get_today_and_now, jsonify_links, load_custom_repo_mappings, str2bool, wkt2geom
+from pycsw.core.util import bind_url, get_today_and_now, jsonify_links, load_custom_repo_mappings, load_record_transform, str2bool, wkt2geom
 from pycsw.ogc.api.oapi import gen_oapi
 from pycsw.ogc.api.util import match_env_var, render_j2_template, to_json, to_rfc3339
 from pycsw.ogc.pubsub import publish_message
@@ -148,6 +148,10 @@ class API:
             msg = f'Could not load repository {err}'
             LOGGER.exception(msg)
             raise
+
+        self._record_transform_func = load_record_transform(
+            self.config['server'].get('record_transform')
+        )
 
         if self.config.get('pubsub') is not None:
             LOGGER.debug('Loading PubSub client')
@@ -863,6 +867,7 @@ class API:
         response['numberReturned'] = returned
 
         for record in records:
+            record = self._record_transform(record)
             response['features'].append(record2json(record, self.config['server']['url'], collection, self.mode))
 
         response['federatedSearchResults'] = {}
@@ -1030,6 +1035,7 @@ class API:
         LOGGER.debug(f'Querying repository for item {item}')
         try:
             record = self.repository.query_ids([item])[0]
+            record = self._record_transform(record)
             response = record2json(record, self.config['server']['url'],
                                    collection, self.mode)
         except IndexError:
@@ -1379,6 +1385,12 @@ class API:
             facets_results[facet]['buckets'].sort(key=itemgetter('count'), reverse=True)
 
         return facets_results
+
+    def _record_transform(self, record):
+        """Apply record transform hook if configured"""
+        if self._record_transform_func is not None:
+            return self._record_transform_func(record)
+        return record
 
 
 def record2json(record, url, collection, mode='ogcapi-records'):

--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -936,6 +936,7 @@ class Csw2(object):
             self.parent.kvp['startposition'], max1)
 
             for res in results:
+                res = self.parent._record_transform(res)
                 node_ = None
                 if self.parent.xslts:
                     try:
@@ -1060,6 +1061,7 @@ class Csw2(object):
                 self.parent.context.md_core_model['mappings']['pycsw:XML']), self.parent.context.parser)
 
         for result in results:
+            result = self.parent._record_transform(result)
             node_ = None
             if self.parent.xslts:
                 try:

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -918,6 +918,7 @@ class Csw3(object):
             self.parent.kvp['startposition'], max1)
 
             for res in results:
+                res = self.parent._record_transform(res)
                 node_ = None
                 if self.parent.xslts:
                     try:
@@ -1116,6 +1117,7 @@ class Csw3(object):
                 self.parent.context.md_core_model['mappings']['pycsw:XML']), self.parent.context.parser)
 
         for result in results:
+            result = self.parent._record_transform(result)
             node_ = None
             if self.parent.xslts:
                 try:

--- a/pycsw/server.py
+++ b/pycsw/server.py
@@ -435,6 +435,10 @@ class Csw(object):
                 locator = 'service'
                 text = 'Could not initialize repository. Check server logs'
 
+        self._record_transform_func = util.load_record_transform(
+            self.config['server'].get('record_transform')
+        )
+
         if self.requesttype == 'POST':
             LOGGER.debug('HTTP POST request')
             LOGGER.debug('CSW version: %s', self.iface.version)
@@ -891,6 +895,12 @@ class Csw(object):
                     LOGGER.debug(f'{uprh.scheme} sent successfully.')
                 except Exception as err:
                     LOGGER.exception(f'Error processing {uprh.scheme}')
+
+    def _record_transform(self, record):
+        """Apply record transform hook if configured"""
+        if self._record_transform_func is not None:
+            return self._record_transform_func(record)
+        return record
 
     def _render_xslt(self, res):
         ''' Validate and render XSLT '''

--- a/tests/unittests/test_record_transform.py
+++ b/tests/unittests/test_record_transform.py
@@ -1,0 +1,129 @@
+# =================================================================
+#
+# Authors: Armin Arndt
+#
+# Copyright (c) 2026 Armin Arndt
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+"""Unit tests for server.record_transform hook"""
+
+import textwrap
+
+import pytest
+
+from pycsw.core.util import load_record_transform
+
+
+class FakeRecord:
+    """Minimal stand-in for a pycsw ORM record object."""
+    def __init__(self, keywords=''):
+        self.keywords = keywords
+        self.identifier = 'test-id'
+        self.title = 'Test Record'
+
+
+# ---------------------------------------------------------------------------
+# load_record_transform tests
+# ---------------------------------------------------------------------------
+
+def test_load_record_transform_none():
+    assert load_record_transform(None) is None
+    assert load_record_transform('') is None
+
+
+def test_load_record_transform_from_file(tmp_path):
+    transform_file = tmp_path / 'mytransform.py'
+    transform_file.write_text(textwrap.dedent("""
+        def record_transform(record):
+            if record.keywords:
+                record.keywords = ','.join(
+                    kw for kw in record.keywords.split(',')
+                    if not kw.startswith('_internal_')
+                )
+            return record
+    """))
+    func = load_record_transform(str(transform_file))
+    assert callable(func)
+
+
+def test_load_record_transform_missing_callable(tmp_path):
+    bad_file = tmp_path / 'bad.py'
+    bad_file.write_text("x = 1\n")
+    with pytest.raises(ValueError, match="must define a callable named 'record_transform'"):
+        load_record_transform(str(bad_file))
+
+
+def test_load_record_transform_missing_module():
+    with pytest.raises(ValueError, match='Could not load record transform module'):
+        load_record_transform('nonexistent.module.that.does.not.exist')
+
+
+# ---------------------------------------------------------------------------
+# Functional behaviour tests
+# ---------------------------------------------------------------------------
+
+def test_transform_filters_keywords(tmp_path):
+    transform_file = tmp_path / 'transform.py'
+    transform_file.write_text(textwrap.dedent("""
+        def record_transform(record):
+            if record.keywords:
+                record.keywords = ','.join(
+                    kw for kw in record.keywords.split(',')
+                    if not kw.startswith('_internal_')
+                )
+            return record
+    """))
+    func = load_record_transform(str(transform_file))
+    record = FakeRecord(keywords='climate,_internal_tag,ocean,_internal_private')
+    result = func(record)
+    assert result.keywords == 'climate,ocean'
+
+
+def test_transform_no_keywords(tmp_path):
+    transform_file = tmp_path / 'transform.py'
+    transform_file.write_text(textwrap.dedent("""
+        def record_transform(record):
+            if record.keywords:
+                record.keywords = ','.join(
+                    kw for kw in record.keywords.split(',')
+                    if not kw.startswith('_internal_')
+                )
+            return record
+    """))
+    func = load_record_transform(str(transform_file))
+    record = FakeRecord(keywords=None)
+    result = func(record)
+    assert result.keywords is None
+
+
+def test_transform_returns_record(tmp_path):
+    transform_file = tmp_path / 'transform.py'
+    transform_file.write_text(textwrap.dedent("""
+        def record_transform(record):
+            return record
+    """))
+    func = load_record_transform(str(transform_file))
+    record = FakeRecord(keywords='topic1,topic2')
+    result = func(record)
+    assert result is record


### PR DESCRIPTION
# Overview

pycsw currently offers no unified intervention point to modify records before they are returned to clients. Existing mechanisms are either format-specific (XSLT → CSW XML only, Jinja2 → OGC API HTML only) or absent entirely from the OGC API pipeline.

This PR introduces a `server.record_transform` configuration option that accepts a file path or dotted module name pointing to a user-supplied Python callable. The callable receives the SQLAlchemy ORM record object after database retrieval and before serialization, and must return it (optionally modified). A single hook covers all supported protocols and output formats:

| Format | Covered |
|---|---|
| OGC API Records — JSON | ✅ |
| OGC API Records — HTML | ✅ |
| OGC API Records — application/xml | ✅ |
| CSW 2.0.2 — all output schemas | ✅ |
| CSW 3.0 — all output schemas | ✅  |

pycsw serves metadata records in multiple formats, each with its own transformation mechanism:
- **CSW XML** — supports XSLT stylesheets via `xslt:` configuration
- **OGC API HTML** — supports customisation via Jinja2 templates
- **OGC API JSON** — no official transformation option exists
- **OGC API application/xml** — no transformation option exists

Operators who need to modify record content before delivery — for example, stripping internal keywords added at ingest time, redacting sensitive fields, or normalising values — must implement separate solutions for each format. There is no single point where a transformation can be applied uniformly across all protocols and output formats.

This PR closes that gap with a single hook that runs after database retrieval and before any format-specific serialization, making it unnecessary to maintain parallel format-specific workarounds.


# Related Issue / Discussion

# Additional Information

Full documentation for this feature is available in `docs/record-transform.rst`, covering configuration, the two-representation model (individual fields vs. `record.xml`), format-specific serialization behaviour, an ISO 19139 example with raw XML rewriting, Docker volume injection, dotted module path support, and security considerations.

Unit tests are located in `tests/unittests/test_record_transform.py` and cover loader behaviour (None/empty input, file loading, missing callable, missing module) as well as functional behaviour (keyword filtering, null keywords, identity passthrough).

## Example `transform.py`

```python
from lxml import etree

_PREFIXES = ('source:', 'catalog:', 'organisation:', 'transaction:', 'sub_organisation:')

_NS = {
    'gmd': 'http://www.isotc211.org/2005/gmd',
    'gco': 'http://www.isotc211.org/2005/gco',
}

def record_transform(record):
    if record.keywords:
        record.keywords = ','.join(
            kw for kw in record.keywords.split(',')
            if not kw.strip().startswith(_PREFIXES)
        )

    if record.xml:
        try:
            xml_in = record.xml if isinstance(record.xml, bytes) else record.xml.encode('utf-8')
            root = etree.fromstring(xml_in)
            for md_kw in root.findall('.//gmd:MD_Keywords', _NS):
                for kw_el in md_kw.findall('gmd:keyword', _NS):
                    cs = kw_el.find('gco:CharacterString', _NS)
                    if cs is not None and cs.text and cs.text.strip().startswith(_PREFIXES):
                        md_kw.remove(kw_el)
                if not md_kw.findall('gmd:keyword', _NS):
                    parent = md_kw.getparent()
                    if parent is not None:
                        parent.getparent().remove(parent)
            record.xml = etree.tostring(root, encoding='unicode')
        except Exception as e:
            print(f'record_transform XML error: {e}')

    return record
```

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute **feature/record-transform-hook** to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
