### PR TITLE
Register template filters on the fallback Jinja2 environment

### DIFF
--- a/pycsw/ogc/api/util.py
+++ b/pycsw/ogc/api/util.py
@@ -219,6 +219,8 @@ def render_j2_template(config, template, data):
             LOGGER.debug(err)
             LOGGER.debug('Custom template not found; using default')
             env = Environment(loader=FileSystemLoader(TEMPLATES))
+            env.filters['to_json'] = to_json
+            env.globals.update(to_json=to_json)
             template = env.get_template(template)
         else:
             raise

--- a/tests/unittests/test_ogc_api_util.py
+++ b/tests/unittests/test_ogc_api_util.py
@@ -1,0 +1,70 @@
+# =================================================================
+#
+# Authors: Tom Kralidis
+#
+# Copyright (c) 2026 Tom Kralidis
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+"""Unit tests for pycsw.ogc.api.util"""
+
+import pytest
+
+from pycsw.ogc.api import util
+
+pytestmark = pytest.mark.unit
+
+TEMPLATE_USING_TO_JSON = "{{ data | to_json }}"
+
+
+def test_render_j2_template_custom_templates_path(tmp_path, monkeypatch):
+    default_templates = tmp_path / 'default'
+    default_templates.mkdir()
+    (default_templates / 'items.html').write_text(TEMPLATE_USING_TO_JSON)
+    monkeypatch.setattr(util, 'TEMPLATES', str(default_templates))
+
+    custom_templates = tmp_path / 'custom'
+    custom_templates.mkdir()
+    (custom_templates / 'items.html').write_text('custom')
+
+    config = {'server': {'templates': {'path': str(custom_templates)}}}
+
+    assert util.render_j2_template(config, 'items.html', {}) == 'custom'
+
+
+def test_render_j2_template_fallback_keeps_filters(tmp_path, monkeypatch):
+    """a template missing from templates.path falls back to the default
+    templates, which must keep the to_json filter registered"""
+
+    default_templates = tmp_path / 'default'
+    default_templates.mkdir()
+    (default_templates / 'items.html').write_text(TEMPLATE_USING_TO_JSON)
+    monkeypatch.setattr(util, 'TEMPLATES', str(default_templates))
+
+    custom_templates = tmp_path / 'custom'
+    custom_templates.mkdir()
+    (custom_templates / 'item.html').write_text('custom')
+
+    config = {'server': {'templates': {'path': str(custom_templates)}}}
+
+    assert util.render_j2_template(config, 'items.html', {}) == '{}'


### PR DESCRIPTION
# Overview

`render_j2_template()` registers the `to_json` filter on the Environment it
creates, but when a template is missing from a custom `server.templates.path`
the fallback Environment for the built-in templates is created without it. Any
built-in template using `{{ ... | to_json }}` (`items.html`, `item.html`,
`stac_items.html`) then fails with
`TemplateAssertionError: No filter named 'to_json'`, so a partial custom
templates directory returns HTTP 500 instead of falling back cleanly.

This registers the filter and global on the fallback environment too.

# Related Issue / Discussion

Closes #1236.

# Additional Information

New `tests/unittests/test_ogc_api_util.py` covers both the custom-template
override and the fallback path; the fallback test fails with the exact reported
`TemplateAssertionError` without this change and passes with it. `tests/unittests`
is green (146 passed) and flake8 is clean on both changed files.

This change was prepared with AI assistance; the regression test was run locally
and fails without the fix.

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute bugfix to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
