### PR TITLE
Prevent facets endpoint failure when facets are not configured

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -577,7 +577,7 @@ class API:
             LOGGER.exception(msg)
             return self.get_exception(400, headers_, 'InvalidParameterValue', msg)
 
-        for value in self.config['repository']['facets']:
+        for value in self.facets:
             facets_[value] = {
                 'type': 'term',
                 'property': value,

--- a/tests/functionaltests/suites/oarec/test_oarec_functional.py
+++ b/tests/functionaltests/suites/oarec/test_oarec_functional.py
@@ -141,6 +141,17 @@ def test_facets(config):
     assert status == 400
 
 
+def test_facets_not_configured(config):
+    config['repository'].pop('facets')
+
+    api = API(config)
+    headers, status, content = api.facets_({}, {})
+    content = json.loads(content)
+
+    assert status == 200
+    assert 'type' in content['facets']
+
+
 def test_items(config):
     api = API(config)
     headers, status, content = api.items({}, None, {})


### PR DESCRIPTION
# Overview

`API.facets_()` read `config['repository']['facets']` directly, so a configuration without a `repository.facets` entry raised `KeyError: 'facets'` instead of returning a response. `API.__init__` already resolves the same setting with a default (`self.facets = self.config['repository'].get('facets', ['type'])`), so `facets_()` now uses that attribute, matching the rest of the class.

# Related Issue / Discussion

Closes #1240

# Additional Information

Regression test added to `tests/functionaltests/suites/oarec/test_oarec_functional.py` next to `test_facets`; it fails with `KeyError: 'facets'` without the change and passes with it. Full `tests/functionaltests/suites/oarec/` suite: 18 passed.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.

# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute bugfix #1240 to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
