### PR TITLE
SQLAlchemy: bind query parameters

### DIFF
--- a/pycsw/core/pygeofilter_evaluate.py
+++ b/pycsw/core/pygeofilter_evaluate.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2021 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -109,7 +109,7 @@ class PycswFilterEvaluator(SQLAlchemyFilterEvaluator):
                 self._pycsw_dbtype.startswith('postgres')):
             if '%' not in node.pattern:
                 LOGGER.debug('Kicking into PostgreSQL FTS mode')
-                return text(f"plainto_tsquery('english', '{node.pattern}') @@ anytext_tsvector")  # noqa
+                return text("plainto_tsquery('english', :node_pattern') @@ anytext_tsvector").bindparams(node_pattern=node.pattern)  # noqa
 
         LOGGER.debug('Default ILIKE behaviour')
         return filters.like(

--- a/tests/functionaltests/suites/oarec/test_oarec_functional.py
+++ b/tests/functionaltests/suites/oarec/test_oarec_functional.py
@@ -297,6 +297,18 @@ def test_items(config):
     assert content['numberReturned'] == 2
     assert len(content['features']) == content['numberReturned']
 
+    cql_json = {'op': 'like', 'args': [{'property': 'anytext'}, "x') OR (1=1) --"]}  # noqa
+    content = json.loads(api.items({}, cql_json, {})[2])
+    assert content['numberMatched'] == 0
+    assert content['numberReturned'] == 0
+    assert len(content['features']) == content['numberReturned']
+
+    cql_json = {'op': 'like', 'args':[{'property': 'anytext'}, "nomatch') @@ anytext_tsvector OR (1=1) OR plainto_tsquery('english','x"]}  # noqa
+    content = json.loads(api.items({}, cql_json, {})[2])
+    assert content['numberMatched'] == 0
+    assert content['numberReturned'] == 0
+    assert len(content['features']) == content['numberReturned']
+
     headers, status, content = api.items({}, None, {}, collection='foo')
     assert status == 400
 

--- a/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
+++ b/tests/functionaltests/suites/stac_api/test_stac_api_functional.py
@@ -839,6 +839,18 @@ def test_items(config):
     content = json.loads(api.items({}, cql_json, {})[2])
     assert content['features'][0]['id'] == 'S2A_MSIL2A_20241128T092331_R093_T34SEJ_20241128T122153'  # noqa
 
+    cql_json = {'op': 'like', 'args': [{'property': 'anytext'}, "x') OR (1=1) --"]}  # noqa
+    content = json.loads(api.items({}, cql_json, {})[2])
+    assert content['numberMatched'] == 0
+    assert content['numberReturned'] == 0
+    assert len(content['features']) == content['numberReturned']
+
+    cql_json = {'op': 'like', 'args':[{'property': 'anytext'}, "nomatch') @@ anytext_tsvector OR (1=1) OR plainto_tsquery('english','x"]}  # noqa
+    content = json.loads(api.items({}, cql_json, {})[2])
+    assert content['numberMatched'] == 0
+    assert content['numberReturned'] == 0
+    assert len(content['features']) == content['numberReturned']
+
 
 def test_item(config):
     api = STACAPI(config)


### PR DESCRIPTION
# Overview
This PR fixes pygeofilter text expressions to use SQLAlchemy's `bindparams` functionality to safeguard incoming filters/queries.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
