### PR TITLE
add further config= checking

### DIFF
--- a/pycsw/wsgi.py
+++ b/pycsw/wsgi.py
@@ -7,7 +7,7 @@
 #
 # Copyright (c) 2015 Adam Hinz
 # Copyright (c) 2017 Ricardo Garcia Silva
-# Copyright (c) 2024 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -207,9 +207,11 @@ def get_configuration_path(process_environment, request_environment,
     query_string = request_environment.get("QUERY_STRING", "").lower()
 
     for kvp in query_string.split('&'):
-        if "config" in kvp:
-            configuration_path = unquote(kvp.split('=')[1])
-            break
+        if kvp:
+            key, value = kvp.split('=')
+            if key == 'config':
+                configuration_path = unquote(value)
+                break
     else:
         # did not find any `config` parameter in the request
         # lets try the process env, request env and fallback to

--- a/tests/unittests/test_wsgi.py
+++ b/tests/unittests/test_wsgi.py
@@ -4,7 +4,7 @@
 #          Tom Kralidis <tomkralidis@gmail.com>
 #
 # Copyright (c) 2017 Ricardo Garcia Silva
-# Copyright (c) 2024 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -83,6 +83,12 @@ def test_get_pycsw_root_path(process_env, wsgi_env, fake_dir, expected):
         "dummy",
         "/other/path/other.yml"
     ),
+    (
+        {"PYCSW_CONFIG": "default.yml"},
+        {"QUERY_STRING": "configparam=/other/path/other.yml"},
+        "dummy",
+        "default.yml"
+    )
 ])
 def test_get_configuration_path(process_env, wsgi_env, pycsw_root, expected):
     result = wsgi.get_configuration_path(process_env, wsgi_env, pycsw_root)


### PR DESCRIPTION
# Overview
This PR adds further constraints/checks when pycsw's CSW `config=` query parameter is specified by a client.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
