### PR TITLE
safeguard output in Jinja2 templates

### DIFF
--- a/pycsw/ogc/api/util.py
+++ b/pycsw/ogc/api/util.py
@@ -4,7 +4,7 @@
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #          Angelos Tzotsos <tzotsos@gmail.com>
 #
-# Copyright (c) 2025 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 # Copyright (c) 2021 Angelos Tzotsos
 #
 # Permission is hereby granted, free of charge, to any person
@@ -169,9 +169,9 @@ def yaml_dump(dict_: dict, destfile: str) -> bool:
     return True
 
 
-def to_json(dict_, pretty=False):
+def to_json(dict_: dict, pretty: bool = False) -> str:
     """
-    Serialize dict to json
+    Serialize dict to JSON
 
     :param dict_: `dict` of JSON representation
     :param pretty: `bool` of whether to prettify JSON (default is `False`)
@@ -184,8 +184,15 @@ def to_json(dict_, pretty=False):
     else:
         indent = None
 
-    return json.dumps(dict_, default=json_serial,
-                      indent=indent)
+    LOGGER.debug('Dumping JSON')
+    json_dump = json.dumps(dict_, default=json_serial, indent=indent,
+                           separators=(',', ':'))
+
+    LOGGER.debug('Escaping < and >')
+    json_dump = json_dump.replace('<', '&lt;')
+    json_dump = json_dump.replace('>', '&gt;')
+
+    return json_dump
 
 
 def render_j2_template(config, template, data):

--- a/pycsw/templates/items.html
+++ b/pycsw/templates/items.html
@@ -165,9 +165,9 @@ endmacro %}
             {% for rec in data['features'] %}
             <tr>
               {% if 'properties' in rec %}
-              <td id="{{ rec['id'] }}"><a title="{{ rec['properties'].get('title', rec['id']) }}" href="{{ config['server']['url'] }}/collections/{{ data['collection'] }}/items/{{ rec['id'] }}">{{ rec['properties'].get('title', rec['id']) }}</a></td>
+              <td id="{{ rec['id'] }}"><a title="{{ rec['properties'].get('title', rec['id']) | e }}" href="{{ config['server']['url'] }}/collections/{{ data['collection'] }}/items/{{ rec['id'] }}">{{ rec['properties'].get('title', rec['id']) | e }}</a></td>
               {% else %}
-              <td id="{{ rec['id'] }}"><a title="{{ rec.get('title', rec['id']) }}" href="{{ config['server']['url'] }}/collections/{{ data['collection'] }}/items/{{ rec['id'] }}">{{ rec.get('title', rec['id']) }}</a></td>
+              <td id="{{ rec['id'] }}"><a title="{{ rec.get('title', rec['id']) | e }}" href="{{ config['server']['url'] }}/collections/{{ data['collection'] }}/items/{{ rec['id'] }}">{{ rec.get('title', rec['id']) | e }}</a></td>
               {% endif %}
               {% if 'properties' in rec %}
                 {% if 'type' in rec['properties'] %}

--- a/tests/functionaltests/suites/oarec/test_oarec_util.py
+++ b/tests/functionaltests/suites/oarec/test_oarec_util.py
@@ -1,0 +1,54 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#
+# Copyright (c) 2026 Tom Kralidis
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+from xml.sax.saxutils import unescape
+
+import pytest
+
+from pycsw.ogc.api.util import to_json
+
+pytestmark = pytest.mark.functional
+
+
+@pytest.mark.parametrize('data,minified,pretty_printed', [
+    [{'foo': 'bar'}, '{"foo":"bar"}', '{\n    "foo":"bar"\n}'],
+    [{'foo<script>alert("hi")</script>': 'bar'},
+     '{"foo&lt;script&gt;alert(\\"hi\\")&lt;/script&gt;":"bar"}',
+     '{\n    "foo&lt;script&gt;alert(\\"hi\\")&lt;/script&gt;":"bar"\n}']
+])
+def test_to_json(data, minified, pretty_printed):
+    output = to_json(data)
+    assert output == minified
+    assert to_json(data, pretty=True) == pretty_printed
+
+    unescaped_output = unescape(output)
+    if '&lt;' in output:
+        assert '<' in unescaped_output
+    if '&gt;' in output:
+        assert '>' in unescaped_output


### PR DESCRIPTION
# Overview
This PR safeguards Jinja2 output, preventing XSS on HTML templates
# Related Issue / Discussion
None
# Additional Information
Inspired/borrowed from pygeoapi.
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
