### PR TITLE
Security policy: update supported versions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,4 @@ The pycsw Project Steering Committee (PSC) will release patches for security vul
 | Version | Supported          |
 | ------- | ------------------ |
 | 2.6.x   | :white_check_mark: |
-| 2.4.x   | :x: |
-| 2.2.x   | :x: |
-| 2.0.x   | :x: |
-| < 2.0   | :x:                |
+| < 2.6.x   | :x: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ The pycsw Project Steering Committee (PSC) will release patches for security vul
 | Version | Supported          |
 | ------- | ------------------ |
 | 2.6.x   | :white_check_mark: |
-| 2.4.x   | :white_check_mark: |
-| 2.2.x   | :white_check_mark: |
-| 2.0.x   | :white_check_mark: |
+| 2.4.x   | :x: |
+| 2.2.x   | :x: |
+| 2.0.x   | :x: |
 | < 2.0   | :x:                |


### PR DESCRIPTION
# Overview
This PR updates pycsw's security policy to support only the latest stable version (currently 2.6.x).

cc @kalxas @pvgenuchten @ricardogsilva 
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
